### PR TITLE
Move setup.py to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,31 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
+[project]
+name = "paas-app-charmer"
+version = "0.2.0"
+description = "Companion library for 12-factor charms"
+authors = [
+    {name = "Canonical IS DevOps team", email="is-devops-team@canonical.com"},
+]
+requires-python = ">=3.10"
+dynamic = ["dependencies"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+]
+
+
+[project.urls]
+Repository = "https://github.com/canonical/paas-app-charmer"
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}
+
+[tool.setuptools.package-data]
+paas_app_charmer = ["**/cos/**", "**/cos/**/.**"]
 
 # Testing tools configuration
 [tool.coverage.run]

--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,5 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
-
-import pathlib
-
 from setuptools import setup
 
-requirements_txt = pathlib.Path(__file__).parent / "requirements.txt"
-requirements = requirements_txt.read_text(encoding="utf-8").splitlines()
-
-setup(
-    name="paas-app-charmer",
-    version="0.2.0",
-    description="Companion library for 12-factor charms",
-    url="https://github.com/canonical/paas-app-charmer",
-    author="Canonical IS DevOps team",
-    author_email="is-devops-team@canonical.com",
-    install_requires=requirements,
-    package_data={"paas_app_charmer": ["**/cos/**", "**/cos/**/.**"]},
-    classifiers=[
-        "Development Status :: 3 - Alpha",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: Apache Software License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3",
-    ],
-    python_requires=">=3.10",
-)
+setup()


### PR DESCRIPTION
### Overview

<!-- A high level overview of the change -->
Migrates the metadata stored in `setup.py` to `pyproject.toml`. A side-effect of this change is that installs from the sdist work, as `requirements.txt` is included. (You can check this yourself by running `python -m build` with and without this change.)

### Rationale

<!-- The reason the change is needed -->
While setup.py is [not actually deprecated](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/), modern tools tend to expect this data in pyproject.toml.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
None

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
None

### Library Changes

<!-- Any changes to charm libraries -->None

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
I don't have access to tag this PR :-)