### PR TITLE
Add log rotation for Gunicorn access and error logs

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -11,7 +11,7 @@ jobs:
       charmcraft-repository: weiiwang01/charmcraft
       charmcraft-ref: update-12f
       modules: '["test_charm", "test_proxy", "test_cos", "test_database", "test_db_migration", "test_django"]'
-      rockcraft-repository: weiiwang01/rockcraft
-      rockcraft-ref: add-django-framework
+      rockcraft-repository: canonical/rockcraft
+      rockcraft-ref: feature/12f
       juju-channel: 3.1/stable
       channel: 1.29-strict/stable

--- a/paas_app_charmer/_gunicorn/logrotate.py
+++ b/paas_app_charmer/_gunicorn/logrotate.py
@@ -5,7 +5,7 @@
 
 """Rotate Gunicorn logs.
 
-It will be injected into the container and must not dependencies on non-standard libraries.
+It will be injected into the container and does not depend on non-standard libraries.
 """
 import argparse
 import datetime

--- a/paas_app_charmer/_gunicorn/logrotate.py
+++ b/paas_app_charmer/_gunicorn/logrotate.py
@@ -7,10 +7,13 @@
 
 It will be injected into the container and does not depend on non-standard libraries.
 """
+
 import argparse
 import datetime
 import glob
 import os
+
+# this script runs similarly to a shell script, disable the warning for using subprocess
 import subprocess  # nosec B404
 import time
 

--- a/paas_app_charmer/_gunicorn/logrotate.py
+++ b/paas_app_charmer/_gunicorn/logrotate.py
@@ -12,6 +12,7 @@ import argparse
 import datetime
 import glob
 import os
+
 # this script runs similarly to a shell script, disable the warning for using subprocess
 import subprocess  # nosec B404
 import time

--- a/paas_app_charmer/_gunicorn/logrotate.py
+++ b/paas_app_charmer/_gunicorn/logrotate.py
@@ -1,0 +1,60 @@
+#!/bin/python3
+
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Rotate Gunicorn logs.
+
+It will be injected into the container and must not dependencies on non-standard libraries.
+"""
+import argparse
+import datetime
+import glob
+import os
+import subprocess  # nosec B404
+import time
+
+KEEP_ARCHIVES = 8
+MAX_SIZE = 256 * 1024 * 1024
+
+
+def rotate(filename: str) -> bool:
+    """Rotate the current Gunicorn log file.
+
+    Args:
+        filename: the name of the log file.
+
+    Returns:
+        True if the log file was rotated, False otherwise.
+    """
+    if not os.path.isfile(filename) or os.stat(filename).st_size < MAX_SIZE:
+        return False
+    name, ext = os.path.splitext(filename)
+    archive_name = f"{name}-{datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S')}{ext}"
+    os.rename(filename, archive_name)
+    pattern = f"{name}-*{ext}"
+    files = sorted(glob.glob(pattern), reverse=True)
+    for file in files[KEEP_ARCHIVES:]:
+        os.remove(file)
+    return True
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Rotate Gunicorn logs.")
+    parser.add_argument(
+        "--framework", required=True, help="The WSGI framework name (flask, django)."
+    )
+    args = parser.parse_args()
+    framework = args.framework
+    access_file = f"/var/log/{framework}/access.log"
+    error_file = f"/var/log/{framework}/error.log"
+    while True:
+        time.sleep(60 * 3)
+        # don't know why pylint think this is a constant
+        rotated = rotate(access_file)  # pylint: disable=invalid-name
+        rotated = rotate(error_file) or rotated  # pylint: disable=invalid-name
+        if rotated:
+            # pylint: disable=subprocess-run-check
+            proc = subprocess.run(["/bin/pebble", "signal", "USR1", framework])  # nosec B603
+            if proc.returncode != 0:
+                print("gunicorn hasn't started")

--- a/paas_app_charmer/_gunicorn/logrotate.py
+++ b/paas_app_charmer/_gunicorn/logrotate.py
@@ -12,7 +12,6 @@ import argparse
 import datetime
 import glob
 import os
-
 # this script runs similarly to a shell script, disable the warning for using subprocess
 import subprocess  # nosec B404
 import time

--- a/paas_app_charmer/_gunicorn/observability.py
+++ b/paas_app_charmer/_gunicorn/observability.py
@@ -78,9 +78,4 @@ class Observability(ops.Object):  # pylint: disable=too-few-public-methods
             },
             combine=True,
         )
-        try:
-            container.replan()
-        except ops.pebble.ChangeError:
-            # It's possible for replan to fail if we have a main application in error state.
-            # Ignore this case, as it will start once the main application starts.
-            pass
+        container.start("logrotate.py")

--- a/tests/unit/django/conftest.py
+++ b/tests/unit/django/conftest.py
@@ -33,6 +33,7 @@ def harness_fixture() -> typing.Generator[Harness, None, None]:
     container = "django-app"
     root = harness.get_filesystem_root(container)
     (root / "django/app").mkdir(parents=True)
+    (root / "bin").mkdir(parents=True)
     harness.set_can_connect(container, True)
 
     def check_config_handler(_):

--- a/tests/unit/flask/conftest.py
+++ b/tests/unit/flask/conftest.py
@@ -32,6 +32,7 @@ def harness_fixture() -> typing.Generator[Harness, None, None]:
     harness.set_leader()
     root = harness.get_filesystem_root(FLASK_CONTAINER_NAME)
     (root / "flask/app").mkdir(parents=True)
+    (root / "bin").mkdir(parents=True)
     harness.set_can_connect(FLASK_CONTAINER_NAME, True)
 
     def check_config_handler(_):

--- a/tests/unit/flask/test_charm.py
+++ b/tests/unit/flask/test_charm.py
@@ -97,7 +97,22 @@ def test_log_rotate(tmp_path):
     files = list(tmp_path.iterdir())
     assert len(files) == 1
     archive = files[0]
+    # if the filename doesn't match the pattern, a ValueError will be raised here
     datetime.datetime.strptime(archive.name, "access-%Y-%m-%d-%H-%M-%S.log")
+
+
+def test_log_rotate_not_rotated(tmp_path):
+    """
+    arrange: create a small log file
+    act: run the log rotate function
+    assert: the log file should not be rotated
+    """
+    log_file = tmp_path / "access.log"
+    log_file.touch()
+    assert not logrotate.rotate(str(log_file.absolute()))
+    assert log_file.exists()
+    files = list(tmp_path.iterdir())
+    assert len(files) == 1
 
 
 def test_log_rotate_cleanup(tmp_path):


### PR DESCRIPTION
The original plan for log rotation was to use the [`RotatingFileHandler`](https://docs.python.org/3/library/logging.handlers.html#rotatingfilehandler) logging handler. However, the `RotatingFileHandler` doesn't work in multiprocessing mode, as noted in https://bugs.python.org/issue43107. So instead, in this pull request, using a small Python script to perform the log rotation.