### PR TITLE
Fixes for Django. migrate and python -> python3.

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,2 +1,4 @@
 # ignore CVE introduced by python3-gunicorn
 CVE-2022-40897
+# CVE usr/bin/pebble (gobinary)
+CVE-2023-45288

--- a/examples/django/django_app/manage.py
+++ b/examples/django/django_app/manage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.

--- a/examples/django/rockcraft.yaml
+++ b/examples/django/rockcraft.yaml
@@ -5,8 +5,10 @@ name: django-app
 summary: Example Django application image.
 description: Example Django application image.
 version: "0.1"
-base: bare
+base: ubuntu@22.04
 license: Apache-2.0
+platforms:
+  amd64:
 
 extensions:
   - django-framework

--- a/examples/flask/test_db_rock/rockcraft.yaml
+++ b/examples/flask/test_db_rock/rockcraft.yaml
@@ -4,8 +4,10 @@ name: test-db-flask
 summary: Default Flask application image.
 description: Default Flask application image.
 version: "0.1"
-base: bare
+base: ubuntu@22.04
 license: Apache-2.0
+platforms:
+  amd64:
 
 extensions:
   - flask-framework

--- a/paas_app_charmer/_gunicorn/charm.py
+++ b/paas_app_charmer/_gunicorn/charm.py
@@ -147,7 +147,7 @@ class GunicornBase(abc.ABC, ops.CharmBase):  # pylint: disable=too-many-instance
             event.fail("only leader unit can rotate secret key")
             return
         if not self._secret_storage.is_initialized:
-            event.fail("flask charm is still initializing")
+            event.fail("charm is still initializing")
             return
         self._secret_storage.reset_secret_key()
         event.set_results({"status": "success"})
@@ -190,10 +190,13 @@ class GunicornBase(abc.ABC, ops.CharmBase):  # pylint: disable=too-many-instance
         return True
 
     def restart(self) -> None:
-        """Restart or start the flask service if not started with the latest configuration."""
+        """Restart or start the service if not started with the latest configuration."""
         if not self.is_ready():
             return
         try:
+            self._update_app_and_unit_status(
+                ops.MaintenanceStatus("Preparing service for restart")
+            )
             self._wsgi_app.restart()
         except CharmConfigInvalidError as exc:
             self._update_app_and_unit_status(ops.BlockedStatus(exc.msg))

--- a/paas_app_charmer/_gunicorn/wsgi_app.py
+++ b/paas_app_charmer/_gunicorn/wsgi_app.py
@@ -118,6 +118,9 @@ class WsgiApp:  # pylint: disable=too-few-public-methods
             migration_command = ["bash", "-eo", "pipefail", "migrate.sh"]
         if self._container.exists(app_dir / "migrate.py"):
             migration_command = ["python3", "migrate.py"]
+        if self._container.exists(app_dir / "manage.py"):
+            # Django migrate command
+            migration_command = ["python3", "manage.py", "migrate"]
         if migration_command:
             self._database_migration.run(
                 command=migration_command,

--- a/paas_app_charmer/_gunicorn/wsgi_app.py
+++ b/paas_app_charmer/_gunicorn/wsgi_app.py
@@ -117,7 +117,7 @@ class WsgiApp:  # pylint: disable=too-few-public-methods
         if self._container.exists(app_dir / "migrate.sh"):
             migration_command = ["bash", "-eo", "pipefail", "migrate.sh"]
         if self._container.exists(app_dir / "migrate.py"):
-            migration_command = ["python", "migrate.py"]
+            migration_command = ["python3", "migrate.py"]
         if migration_command:
             self._database_migration.run(
                 command=migration_command,

--- a/paas_app_charmer/django/charm.py
+++ b/paas_app_charmer/django/charm.py
@@ -62,7 +62,7 @@ class Charm(GunicornBase):  # pylint: disable=too-many-instance-attributes
             "debug": self.config.get("django-debug"),
             "secret_key": self.config.get("django-secret-key"),
         }
-        allowed_hosts = self.config.get("django-allowed-hosts", "")
+        allowed_hosts = str(self.config.get("django-allowed-hosts", ""))
         if allowed_hosts.strip():
             django_config["allowed_hosts"] = [h.strip() for h in allowed_hosts.split(",")]
         else:

--- a/paas_app_charmer/django/charm.py
+++ b/paas_app_charmer/django/charm.py
@@ -99,7 +99,7 @@ class Charm(GunicornBase):  # pylint: disable=too-many-instance-attributes
         try:
             password = secrets.token_urlsafe(16)
             self._container.exec(
-                ["python", "manage.py", "createsuperuser", "--noinput"],
+                ["python3", "manage.py", "createsuperuser", "--noinput"],
                 environment={
                     "DJANGO_SUPERUSER_PASSWORD": password,
                     "DJANGO_SUPERUSER_USERNAME": event.params["username"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 [project]
 name = "paas-app-charmer"
-version = "1.0.0"
+version = "1.0.1"
 description = "Companion library for PaaS app charmer."
 readme = "README.md"
 authors = [

--- a/tests/integration/django/test_django.py
+++ b/tests/integration/django/test_django.py
@@ -31,10 +31,9 @@ async def test_django_webserver_timeout(django_app, get_unit_ips, timeout):
         assert requests.get(
             f"http://{unit_ip}:8000/sleep?duration={timeout - 1}", timeout=safety_timeout
         ).ok
-        with pytest.raises(requests.ConnectionError):
-            requests.get(
-                f"http://{unit_ip}:8000/sleep?duration={timeout + 1}", timeout=safety_timeout
-            )
+        assert not requests.get(
+            f"http://{unit_ip}:8000/sleep?duration={timeout + 1}", timeout=safety_timeout
+        )
 
 
 async def test_django_database_migration(django_app, get_unit_ips):

--- a/tests/integration/flask/test_charm.py
+++ b/tests/integration/flask/test_charm.py
@@ -61,10 +61,9 @@ async def test_flask_webserver_timeout(
         assert requests.get(
             f"http://{unit_ip}:8000/sleep?duration={timeout - 1}", timeout=safety_timeout
         ).ok
-        with pytest.raises(requests.ConnectionError):
-            requests.get(
-                f"http://{unit_ip}:8000/sleep?duration={timeout + 1}", timeout=safety_timeout
-            )
+        assert not requests.get(
+            f"http://{unit_ip}:8000/sleep?duration={timeout + 1}", timeout=safety_timeout
+        ).ok
 
 
 async def test_default_secret_key(

--- a/tests/unit/flask/test_database_migration.py
+++ b/tests/unit/flask/test_database_migration.py
@@ -83,7 +83,7 @@ def test_database_migration(harness: Harness):
     [
         pytest.param("migrate", ["/flask/app/migrate"], id="executable"),
         pytest.param("migrate.sh", ["bash", "-eo", "pipefail", "migrate.sh"], id="shell"),
-        pytest.param("migrate.py", ["python", "migrate.py"], id="python"),
+        pytest.param("migrate.py", ["python3", "migrate.py"], id="python"),
     ],
 )
 def test_database_migrate_command(harness: Harness, file: str, command: list[str]):

--- a/tests/unit/flask/test_database_migration.py
+++ b/tests/unit/flask/test_database_migration.py
@@ -84,6 +84,7 @@ def test_database_migration(harness: Harness):
         pytest.param("migrate", ["/flask/app/migrate"], id="executable"),
         pytest.param("migrate.sh", ["bash", "-eo", "pipefail", "migrate.sh"], id="shell"),
         pytest.param("migrate.py", ["python3", "migrate.py"], id="python"),
+        pytest.param("manage.py", ["python3", "manage.py", "migrate"], id="django"),
     ],
 )
 def test_database_migrate_command(harness: Harness, file: str, command: list[str]):

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ deps =
     flake8-docstrings-complete>=1.0.4
     flake8-docstrings>=1.6.0
     flake8-test-docs
-    flake8<6.0.0
+    flake8
     isort
     types-requests
     types-PyYAML
@@ -49,7 +49,7 @@ deps =
     pep8-naming
     pydocstyle
     pylint
-    pyproject-flake8<6.0.0
+    pyproject-flake8
     pytest_operator
     types-requests
     types-PyYAML


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

This PR includes bug fixes for paas-app-charmer. In particular:
* Replace erroneous python with python3 
* If `manage.py` file exists, use it to run migrations like `python3 manage.py migrate` in the Django way.

Other necessary fixes (the pipeline was not passing):
* Fix Django `rockcraft.yaml` example thas was missing the base and platforms.
* Gunicorn on timeout returns 500 instead of timing out (tests fixed).
* Add CVE to trivyignore, as it is included in the current rock.

The version of the library is increased to 1.0.1.

### Rationale

<!-- The reason the change is needed -->
This fixes were necessary for a cleaner version of Django applications and also to fix the pipeline.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
