### PR TITLE
Upgrade revision of mysql-k8s to 140

### DIFF
--- a/tests/integration/flask/test_database.py
+++ b/tests/integration/flask/test_database.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
     "endpoint,db_name, db_channel, revision, trust",
     [
         ("redis/status", "redis-k8s", "latest/edge", None, True),
-        ("mysql/status", "mysql-k8s", "8.0/stable", "75", True),
+        ("mysql/status", "mysql-k8s", "8.0/stable", "140", True),
         ("postgresql/status", "postgresql-k8s", "14/stable", None, True),
         ("mongodb/status", "mongodb-k8s", "6/beta", None, True),
     ],


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

Tests are failing with mysql-k8s revision 75. Revision 140 is the latest one accepting juju 3.1

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
