### PR TITLE
Add new env variable {framework}_BASE_URL with the ingress url

### DIFF
--- a/paas_app_charmer/_gunicorn/charm.py
+++ b/paas_app_charmer/_gunicorn/charm.py
@@ -301,7 +301,11 @@ class GunicornBase(abc.ABC, ops.CharmBase):  # pylint: disable=too-many-instance
 
     @property
     def _base_url(self) -> str:
-        """TODO."""
+        """Return the base_url for the service.
+
+        This URL will be the ingress URL if there is one, otherwise it will
+        point to the K8S service.
+        """
         if self._ingress.url:
             return self._ingress.url
         return f"http://{self.app.name}.{self.model.name}:{self._workload_config.port}"

--- a/paas_app_charmer/_gunicorn/charm_state.py
+++ b/paas_app_charmer/_gunicorn/charm_state.py
@@ -56,7 +56,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
         wsgi_config: dict[str, int | str] | None = None,
         secret_key: str | None = None,
         integrations: "IntegrationsState | None" = None,
-        ingress_url: str | None = None,
+        base_url: str | None = None,
     ):
         """Initialize a new instance of the CharmState class.
 
@@ -67,7 +67,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
             wsgi_config: The value of the WSGI application specific charm configuration.
             secret_key: The secret storage manager associated with the charm.
             integrations: Information about the integrations.
-            ingress_url: Url returned by the ingress interface.
+            base_url: Base URL for the service.
         """
         self.framework = framework
         self._wsgi_config = wsgi_config if wsgi_config is not None else {}
@@ -75,7 +75,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
         self._is_secret_storage_ready = is_secret_storage_ready
         self._secret_key = secret_key
         self.integrations = integrations or IntegrationsState()
-        self.ingress_url = ingress_url
+        self.base_url = base_url
 
     @classmethod
     def from_charm(  # pylint: disable=too-many-arguments
@@ -88,7 +88,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
         redis_uri: str | None = None,
         s3_connection_info: dict[str, str] | None = None,
         saml_relation_data: typing.MutableMapping[str, str] | None = None,
-        ingress_url: str | None = None,
+        base_url: str | None = None,
     ) -> "CharmState":
         """Initialize a new instance of the CharmState class from the associated charm.
 
@@ -101,7 +101,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
             redis_uri: The redis uri provided by the redis charm.
             s3_connection_info: Connection info from S3 lib.
             saml_relation_data: Relation data from the SAML app.
-            ingress_url: Url returned by the ingress interface.
+            base_url: Base URL for the service.
 
         Return:
             The CharmState instance created by the provided charm.
@@ -128,7 +128,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
             ),
             is_secret_storage_ready=secret_storage.is_initialized,
             integrations=integrations,
-            ingress_url=ingress_url,
+            base_url=base_url,
         )
 
     @property

--- a/paas_app_charmer/_gunicorn/charm_state.py
+++ b/paas_app_charmer/_gunicorn/charm_state.py
@@ -56,6 +56,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
         wsgi_config: dict[str, int | str] | None = None,
         secret_key: str | None = None,
         integrations: "IntegrationsState | None" = None,
+        ingress_url: str | None = None,
     ):
         """Initialize a new instance of the CharmState class.
 
@@ -66,6 +67,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
             wsgi_config: The value of the WSGI application specific charm configuration.
             secret_key: The secret storage manager associated with the charm.
             integrations: Information about the integrations.
+            ingress_url: Url returned by the ingress interface.
         """
         self.framework = framework
         self._wsgi_config = wsgi_config if wsgi_config is not None else {}
@@ -73,6 +75,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
         self._is_secret_storage_ready = is_secret_storage_ready
         self._secret_key = secret_key
         self.integrations = integrations or IntegrationsState()
+        self.ingress_url = ingress_url
 
     @classmethod
     def from_charm(  # pylint: disable=too-many-arguments
@@ -85,6 +88,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
         redis_uri: str | None = None,
         s3_connection_info: dict[str, str] | None = None,
         saml_relation_data: typing.MutableMapping[str, str] | None = None,
+        ingress_url: str | None = None,
     ) -> "CharmState":
         """Initialize a new instance of the CharmState class from the associated charm.
 
@@ -97,6 +101,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
             redis_uri: The redis uri provided by the redis charm.
             s3_connection_info: Connection info from S3 lib.
             saml_relation_data: Relation data from the SAML app.
+            ingress_url: Url returned by the ingress interface.
 
         Return:
             The CharmState instance created by the provided charm.
@@ -123,6 +128,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
             ),
             is_secret_storage_ready=secret_storage.is_initialized,
             integrations=integrations,
+            ingress_url=ingress_url,
         )
 
     @property

--- a/paas_app_charmer/_gunicorn/wsgi_app.py
+++ b/paas_app_charmer/_gunicorn/wsgi_app.py
@@ -72,8 +72,8 @@ class WsgiApp:  # pylint: disable=too-few-public-methods
         config.update(self._charm_state.wsgi_config)
         prefix = f"{self._workload_config.framework.upper()}_"
         env = {f"{prefix}{k.upper()}": self._encode_env(v) for k, v in config.items()}
-        if self._charm_state.ingress_url:
-            env[f"{prefix}BASE_URL"] = self._charm_state.ingress_url
+        if self._charm_state.base_url:
+            env[f"{prefix}BASE_URL"] = self._charm_state.base_url
         secret_key_env = f"{prefix}SECRET_KEY"
         if secret_key_env not in env:
             env[secret_key_env] = self._charm_state.secret_key

--- a/paas_app_charmer/_gunicorn/wsgi_app.py
+++ b/paas_app_charmer/_gunicorn/wsgi_app.py
@@ -72,6 +72,8 @@ class WsgiApp:  # pylint: disable=too-few-public-methods
         config.update(self._charm_state.wsgi_config)
         prefix = f"{self._workload_config.framework.upper()}_"
         env = {f"{prefix}{k.upper()}": self._encode_env(v) for k, v in config.items()}
+        if self._charm_state.ingress_url:
+            env[f"{prefix}BASE_URL"] = self._charm_state.ingress_url
         secret_key_env = f"{prefix}SECRET_KEY"
         if secret_key_env not in env:
             env[secret_key_env] = self._charm_state.secret_key

--- a/tests/integration/flask/conftest.py
+++ b/tests/integration/flask/conftest.py
@@ -20,16 +20,6 @@ from tests.integration.helpers import inject_charm_config, inject_venv
 
 PROJECT_ROOT = pathlib.Path(__file__).parent.parent.parent.parent
 
-import nest_asyncio
-import asyncio
-@pytest.fixture(scope="module")
-def event_loop():
-    nest_asyncio.apply()
-    loop = asyncio.new_event_loop()
-    asyncio._set_running_loop(loop)
-    yield loop
-    loop.close()
-
 
 @pytest.fixture(autouse=True)
 def cwd():

--- a/tests/integration/flask/conftest.py
+++ b/tests/integration/flask/conftest.py
@@ -20,6 +20,16 @@ from tests.integration.helpers import inject_charm_config, inject_venv
 
 PROJECT_ROOT = pathlib.Path(__file__).parent.parent.parent.parent
 
+import nest_asyncio
+import asyncio
+@pytest.fixture(scope="module")
+def event_loop():
+    nest_asyncio.apply()
+    loop = asyncio.new_event_loop()
+    asyncio._set_running_loop(loop)
+    yield loop
+    loop.close()
+
 
 @pytest.fixture(autouse=True)
 def cwd():

--- a/tests/integration/flask/test_charm.py
+++ b/tests/integration/flask/test_charm.py
@@ -210,26 +210,24 @@ async def test_port_without_ingress(
     flask_app: Application,
 ):
     """
-    arrange: build and deploy the flask charm without ingress
-    act: request env variables through the app public address (k8s service)
+    arrange: build and deploy the flask charm without ingres. get service ip
+        address.
+    act: request env variables through the app service ip address.
     assert: the request should success and the env variable FLASK_BASE_URL
-        should point to the service. Check also that the base url can be resolved
-        to the same ip by K8s.
+        should point to the service.
     """
-    status = await model.get_status()
-    public_address = status.applications[flask_app.name].public_address
+    service_hostname = f"{flask_app.name}.{model.name}"
+    action = await flask_app.units[0].run(f"/usr/bin/getent hosts {service_hostname}")
+    result = await action.wait()
+    assert result.status == "completed"
+    assert result.results["return-code"] == 0
+    service_ip = result.results["stdout"].split()[0]
 
-    response = requests.get(f"http://{public_address}:8000/env", timeout=30)
+    response = requests.get(f"http://{service_ip}:8000/env", timeout=30)
 
     assert response.status_code == 200
     env_vars = response.json()
-    assert env_vars["FLASK_BASE_URL"] == f"http://{flask_app.name}.{model.name}:8000"
-    # Check that name {flask_app.name}.{model.name} gets correctly resolved to
-    # the same IP we just checked.
-    action = await flask_app.units[0].run(f"/usr/bin/getent hosts {flask_app.name}.{model.name}")
-    result = await action.wait()
-    assert result.status == "completed"
-    assert public_address in result.results["stdout"]
+    assert env_vars["FLASK_BASE_URL"] == f"http://{service_hostname}:8000"
 
 
 async def test_with_ingress(

--- a/tests/integration/flask/test_charm.py
+++ b/tests/integration/flask/test_charm.py
@@ -211,7 +211,7 @@ async def test_port_without_ingress(
 ):
     """
     arrange: build and deploy the flask charm without ingress
-    act: request env variables throught the app public address (k8s service)
+    act: request env variables through the app public address (k8s service)
     assert: the request should success and the env variable FLASK_BASE_URL
         should point to the service. Unfortunately this hostname is not
         resolved from outside the cluster.
@@ -223,7 +223,7 @@ async def test_port_without_ingress(
 
     assert response.status_code == 200
     env_vars = response.json()
-    assert env_vars['FLASK_BASE_URL'] == f"http://{flask_app.name}.{model.name}:8000"
+    assert env_vars["FLASK_BASE_URL"] == f"http://{flask_app.name}.{model.name}:8000"
 
 
 async def test_with_ingress(

--- a/tests/integration/flask/test_charm.py
+++ b/tests/integration/flask/test_charm.py
@@ -229,7 +229,7 @@ async def test_port_without_ingress(
     action = await flask_app.units[0].run(f"/usr/bin/getent hosts {flask_app.name}.{model.name}")
     result = await action.wait()
     assert result.status == "completed"
-    assert public_address in result.results['stdout']
+    assert public_address in result.results["stdout"]
 
 
 async def test_with_ingress(


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

Add new environment for the ingress url. The env variable name will be "FLASK_BASE_URL" or "DJANGO_BASE_URL".

If there is no ingress, the url returned will be the k8s service. The port hast to be opened for the service to work correctly.

Besides, pebble will be replanned on the relevant ingress events (so the workload can get the new env variable if it has been updated).

Documentation will be updated to include the new env variable when the package gets released to pipy (documentation is currently under review).

### Rationale

<!-- The reason the change is needed -->

Allow the workload to know the ingress url.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
