### PR TITLE
Fix  wrong prefix for secret-key and do not allow extra fields in framework configs.

### DIFF
--- a/examples/fastapi/charm/charmcraft.yaml
+++ b/examples/fastapi/charm/charmcraft.yaml
@@ -43,7 +43,7 @@ config:
       type: string
       description: Path where the prometheus metrics will be scraped.
       default: /metrics
-    secret-key:
+    app-secret-key:
       type: string
       description: Long secret you can use for sessions, csrf or any other thing where
          you need a random secret shared by all units

--- a/paas_app_charmer/fastapi/charm.py
+++ b/paas_app_charmer/fastapi/charm.py
@@ -13,7 +13,7 @@ from paas_app_charmer.app import App, WorkloadConfig
 from paas_app_charmer.charm import PaasCharm
 
 
-class FastAPIConfig(BaseModel, extra=Extra.allow):
+class FastAPIConfig(BaseModel, extra=Extra.ignore):
     """Represent FastAPI builtin configuration values.
 
     Attrs:
@@ -35,7 +35,7 @@ class FastAPIConfig(BaseModel, extra=Extra.allow):
     )
     metrics_port: int | None = Field(alias="metrics-port", default=None, gt=0)
     metrics_path: str | None = Field(alias="metrics-path", default=None, min_length=1)
-    app_secret_key: str | None = Field(alias="secret-key", default=None, min_length=1)
+    app_secret_key: str | None = Field(alias="app-secret-key", default=None, min_length=1)
 
 
 class Charm(PaasCharm):

--- a/paas_app_charmer/go/charm.py
+++ b/paas_app_charmer/go/charm.py
@@ -13,7 +13,7 @@ from paas_app_charmer.app import App, WorkloadConfig
 from paas_app_charmer.charm import PaasCharm
 
 
-class GoConfig(BaseModel, extra=Extra.allow):
+class GoConfig(BaseModel, extra=Extra.ignore):
     """Represent Go builtin configuration values.
 
     Attrs:

--- a/tests/unit/fastapi/test_charm.py
+++ b/tests/unit/fastapi/test_charm.py
@@ -31,7 +31,7 @@ from .constants import DEFAULT_LAYER, FASTAPI_CONTAINER_NAME
         ),
         pytest.param(
             {
-                "secret-key": "foobar",
+                "app-secret-key": "foobar",
                 "webserver-port": 9000,
                 "metrics-port": 9001,
                 "metrics-path": "/othermetrics",

--- a/tests/unit/fastapi/test_charm.py
+++ b/tests/unit/fastapi/test_charm.py
@@ -35,6 +35,7 @@ from .constants import DEFAULT_LAYER, FASTAPI_CONTAINER_NAME
                 "webserver-port": 9000,
                 "metrics-port": 9001,
                 "metrics-path": "/othermetrics",
+                "user-defined-config": "userdefined",
             },
             {
                 "UVICORN_PORT": "9000",
@@ -45,6 +46,7 @@ from .constants import DEFAULT_LAYER, FASTAPI_CONTAINER_NAME
                 "METRICS_PORT": "9001",
                 "METRICS_PATH": "/othermetrics",
                 "APP_SECRET_KEY": "foobar",
+                "APP_USER_DEFINED_CONFIG": "userdefined",
             },
             id="custom config",
         ),

--- a/tests/unit/go/test_app.py
+++ b/tests/unit/go/test_app.py
@@ -31,7 +31,7 @@ from paas_app_charmer.go.charm import GoConfig
         pytest.param(
             {"JUJU_CHARM_HTTP_PROXY": "http://proxy.test"},
             {"extra-config", "extravalue"},
-            {"metrics_port": "9000", "metrics_path": "/m", "secret_key": "notfoobar"},
+            {"metrics-port": "9000", "metrics-path": "/m", "app-secret-key": "notfoobar"},
             IntegrationsState(redis_uri="redis://10.1.88.132:6379"),
             {
                 "APP_PORT": "8080",


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

The correct name for FastAPI config option is `app-secret-key` instead of `secret-key`, as defined by the spec ISD160.

Also, do not allow extra fields in the FrameworkConfig for Go and FastAPI (this was outputting extra env variables with "-", although the correct one was correctly set). 

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
