### PR TITLE
Background tasks

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -14,7 +14,7 @@ jobs:
       extra-arguments: -x --localstack-address 172.17.0.1
       pre-run-script: localstack-installation.sh
       charmcraft-channel: latest/edge
-      modules: '["test_charm.py", "test_cos.py", "test_database.py", "test_db_migration.py", "test_django.py", "test_django_integrations.py", "test_fastapi.py", "test_go.py", "test_integrations.py", "test_proxy.py"]'
+      modules: '["test_charm.py", "test_cos.py", "test_database.py", "test_db_migration.py", "test_django.py", "test_django_integrations.py", "test_fastapi.py", "test_go.py", "test_integrations.py", "test_proxy.py", "test_workers.py"]'
       rockcraft-repository: javierdelapuente/rockcraft
       rockcraft-ref: fastapi-extension
       juju-channel: ${{ matrix.juju-version }}

--- a/examples/flask/test_rock/app.py
+++ b/examples/flask/test_rock/app.py
@@ -72,7 +72,12 @@ if broker_url:
 
     @celery_app.task
     def scheduled_task(scheduler_hostname):
-        """Function to run a schedule task in a worker."""
+        """Function to run a schedule task in a worker.
+
+        The worker that will run this task will add the scheduler hostname argument
+        to the "schedulers" set in Redis, and the worker's hostname to the "workers"
+        set in Redis.
+        """
         worker_hostname = hostname()
         logging.info(
             "scheduler host received %s in worker host %s", scheduler_hostname, worker_hostname

--- a/examples/flask/test_rock/app.py
+++ b/examples/flask/test_rock/app.py
@@ -85,7 +85,7 @@ if broker_url:
         # For that it maybe necessary to exhaust all workers, but not to get the pending tasks
         # too big, so all schedulers can manage to run their scheduled tasks.
         # Celery prefetches tasks, and if they cannot be run they are put in reserved.
-        # If all processes have tasks in reserved, this task will finish inmediatly to not make
+        # If all processes have tasks in reserved, this task will finish immediately to not make
         # queues any longer.
         inspect_obj = celery_app.control.inspect()
         reserved_sizes = [len(tasks) for tasks in inspect_obj.reserved().values()]

--- a/examples/flask/test_rock/app.py
+++ b/examples/flask/test_rock/app.py
@@ -1,7 +1,9 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import logging
 import os
+import socket
 import time
 import urllib.parse
 from urllib.parse import urlparse
@@ -16,10 +18,80 @@ import pymongo.errors
 import pymysql
 import pymysql.cursors
 import redis
+from celery import Celery, Task
 from flask import Flask, g, jsonify, request
+
+
+def hostname():
+    """Get the hostname of the current machine."""
+    return socket.gethostbyname(socket.gethostname())
+
+
+def celery_init_app(app: Flask, broker_url: str) -> Celery:
+    """Initialise celery using the redis connection string.
+
+    See https://flask.palletsprojects.com/en/3.0.x/patterns/celery/#integrate-celery-with-flask.
+    """
+
+    class FlaskTask(Task):
+        def __call__(self, *args: object, **kwargs: object) -> object:
+            with app.app_context():
+                return self.run(*args, **kwargs)
+
+    celery_app = Celery(app.name, task_cls=FlaskTask)
+    celery_app.set_default()
+    app.extensions["celery"] = celery_app
+    app.config.from_mapping(
+        CELERY=dict(
+            broker_url=broker_url,
+            result_backend=broker_url,
+            task_ignore_result=True,
+        ),
+    )
+    celery_app.config_from_object(app.config["CELERY"])
+    return celery_app
+
 
 app = Flask(__name__)
 app.config.from_prefixed_env()
+
+broker_url = os.environ.get("REDIS_DB_CONNECT_STRING")
+# Configure Celery only if Redis is configured
+if broker_url:
+    celery_app = celery_init_app(app, broker_url)
+    redis_client = redis.Redis.from_url(broker_url)
+
+    @celery_app.on_after_configure.connect
+    def setup_periodic_tasks(sender, **kwargs):
+        """Set up periodic tasks in the scheduler."""
+        try:
+            # This will only have an effect in the beat scheduler.
+            sender.add_periodic_task(0.5, scheduled_task.s(hostname()), name="every 0.5s")
+        except NameError as e:
+            logging.exception("Failed to configure the periodic task")
+
+    @celery_app.task
+    def scheduled_task(scheduler_hostname):
+        """Function to run a schedule task in a worker."""
+        worker_hostname = hostname()
+        logging.info(
+            "scheduler host received %s in worker host %s", scheduler_hostname, worker_hostname
+        )
+        redis_client.sadd("schedulers", scheduler_hostname)
+        redis_client.sadd("workers", worker_hostname)
+        logging.info("schedulers: %s", redis_client.smembers("schedulers"))
+        logging.info("workers: %s", redis_client.smembers("workers"))
+        # The goal is to have all workers busy in all processes.
+        # For that it maybe necessary to exhaust all workers, but not to get the pending tasks
+        # too big, so all schedulers can manage to run their scheduled tasks.
+        # Celery prefetches tasks, and if they cannot be run they are put in reserved.
+        # If all processes have tasks in reserved, this task will finish inmediatly to not make
+        # queues any longer.
+        inspect_obj = celery_app.control.inspect()
+        reserved_sizes = [len(tasks) for tasks in inspect_obj.reserved().values()]
+        logging.info("number of reserved tasks %s", reserved_sizes)
+        delay = 0 if min(reserved_sizes) > 0 else 5
+        time.sleep(delay)
 
 
 def get_mysql_database():
@@ -213,14 +285,40 @@ def mongodb_status():
 
 @app.route("/redis/status")
 def redis_status():
-    """Mongodb status endpoint."""
+    """Redis status endpoint."""
     if database := get_redis_database():
         try:
             database.set("foo", "bar")
             return "SUCCESS"
-        except pymongo.errors.PyMongoError:
-            pass
+        except redis.exceptions.RedisError:
+            logging.exception("Error querying redis")
     return "FAIL"
+
+
+@app.route("/redis/clear_celery_stats")
+def redis_celery_clear_stats():
+    """Reset Redis statistics about workers and schedulers."""
+    if database := get_redis_database():
+        try:
+            database.delete("workers")
+            database.delete("schedulers")
+            return "SUCCESS"
+        except redis.exceptions.RedisError:
+            logging.exception("Error querying redis")
+    return "FAIL", 500
+
+
+@app.route("/redis/celery_stats")
+def redis_celery_stats():
+    """Read Redis statistics about workers and schedulers."""
+    if database := get_redis_database():
+        try:
+            worker_set = [str(host) for host in database.smembers("workers")]
+            beat_set = [str(host) for host in database.smembers("schedulers")]
+            return jsonify({"workers": worker_set, "schedulers": beat_set})
+        except redis.exceptions.RedisError:
+            logging.exception("Error querying redis")
+    return "FAIL", 500
 
 
 @app.route("/rabbitmq/send")

--- a/examples/flask/test_rock/requirements.txt
+++ b/examples/flask/test_rock/requirements.txt
@@ -7,3 +7,4 @@ pymongo
 redis[hiredis]
 boto3
 pika
+celery

--- a/examples/flask/test_rock/rockcraft.yaml
+++ b/examples/flask/test_rock/rockcraft.yaml
@@ -11,3 +11,19 @@ platforms:
 
 extensions:
   - flask-framework
+
+services:
+  celery-worker:
+    override: replace
+    # redis is not mandatory in the charm. We do not want the charm to fail inmediately, so the sleep
+    command: bash -c "sleep 5; celery -A app:celery_app worker -c 2 --loglevel DEBUG"
+    startup: enabled
+    user: _daemon_
+    working-dir: /flask/app
+  celery-beat-scheduler:
+    override: replace
+    # redis is not mandatory in the charm. We do not want the charm to fail inmediately, so the sleep
+    command: bash -c "sleep 5; celery -A app:celery_app beat --loglevel DEBUG -s /tmp/celerybeat-schedule"
+    startup: enabled
+    user: _daemon_
+    working-dir: /flask/app

--- a/examples/flask/test_rock/rockcraft.yaml
+++ b/examples/flask/test_rock/rockcraft.yaml
@@ -15,14 +15,14 @@ extensions:
 services:
   celery-worker:
     override: replace
-    # redis is not mandatory in the charm. We do not want the charm to fail inmediately, so the sleep
+    # redis is not mandatory in the charm. We do not want the charm to fail immediately, so the sleep
     command: bash -c "sleep 5; celery -A app:celery_app worker -c 2 --loglevel DEBUG"
     startup: enabled
     user: _daemon_
     working-dir: /flask/app
   celery-beat-scheduler:
     override: replace
-    # redis is not mandatory in the charm. We do not want the charm to fail inmediately, so the sleep
+    # redis is not mandatory in the charm. We do not want the charm to fail immediately, so the sleep
     command: bash -c "sleep 5; celery -A app:celery_app beat --loglevel DEBUG -s /tmp/celerybeat-schedule"
     startup: enabled
     user: _daemon_

--- a/paas_app_charmer/_gunicorn/charm.py
+++ b/paas_app_charmer/_gunicorn/charm.py
@@ -19,7 +19,9 @@ class GunicornBase(PaasCharm):
     @property
     def _workload_config(self) -> WorkloadConfig:
         """Return a WorkloadConfig instance."""
-        return create_workload_config(self._framework_name)
+        return create_workload_config(
+            framework_name=self._framework_name, unit_name=self.unit.name
+        )
 
     def _create_app(self) -> App:
         """Build an App instance for the Gunicorn based charm.

--- a/paas_app_charmer/_gunicorn/workload_config.py
+++ b/paas_app_charmer/_gunicorn/workload_config.py
@@ -12,11 +12,12 @@ APPLICATION_LOG_FILE_FMT = "/var/log/{framework}/access.log"
 APPLICATION_ERROR_LOG_FILE_FMT = "/var/log/{framework}/error.log"
 
 
-def create_workload_config(framework_name: str) -> WorkloadConfig:
+def create_workload_config(framework_name: str, unit_name: str) -> WorkloadConfig:
     """Create an WorkloadConfig for Gunicorn.
 
     Args:
         framework_name: framework name.
+        unit_name: name of the app unit.
 
     Returns:
        new WorkloadConfig
@@ -35,4 +36,5 @@ def create_workload_config(framework_name: str) -> WorkloadConfig:
             pathlib.Path(str.format(APPLICATION_ERROR_LOG_FILE_FMT, framework=framework_name)),
         ],
         metrics_target="*:9102",
+        unit_name=unit_name,
     )

--- a/paas_app_charmer/_gunicorn/wsgi_app.py
+++ b/paas_app_charmer/_gunicorn/wsgi_app.py
@@ -20,6 +20,7 @@ class WsgiApp(App):
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
+        *,
         container: ops.Container,
         charm_state: CharmState,
         workload_config: WorkloadConfig,

--- a/paas_app_charmer/app.py
+++ b/paas_app_charmer/app.py
@@ -208,12 +208,13 @@ class App:
         services[self._workload_config.service_name]["environment"] = self.gen_environment()
 
         for service_name, service in services.items():
+            normalised_service_name = service_name.lower()
             # Add environment variables to all worker processes.
-            if service_name.endswith(WORKER_SUFFIX):
+            if normalised_service_name.endswith(WORKER_SUFFIX):
                 service["environment"] = self.gen_environment()
             # For scheduler processes, add environment variables if
             # the scheduler should run in the unit, disable it otherwise.
-            if service_name.endswith(SCHEDULER_SUFFIX):
+            if normalised_service_name.endswith(SCHEDULER_SUFFIX):
                 if self._workload_config.should_run_scheduler():
                     service["environment"] = self.gen_environment()
                 else:

--- a/paas_app_charmer/app.py
+++ b/paas_app_charmer/app.py
@@ -72,6 +72,7 @@ class App:
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
+        *,
         container: ops.Container,
         charm_state: CharmState,
         workload_config: WorkloadConfig,

--- a/paas_app_charmer/app.py
+++ b/paas_app_charmer/app.py
@@ -17,6 +17,9 @@ from paas_app_charmer.database_migration import DatabaseMigration
 
 logger = logging.getLogger(__name__)
 
+WORKER_SUFFIX = "-worker"
+SCHEDULER_SUFFIX = "-scheduler"
+
 
 @dataclass(kw_only=True)
 class WorkloadConfig:  # pylint: disable=too-many-instance-attributes
@@ -37,6 +40,7 @@ class WorkloadConfig:  # pylint: disable=too-many-instance-attributes
         log_files: list of files to monitor.
         metrics_target: target to scrape for metrics.
         metrics_path: path to scrape for metrics.
+        unit_name: Name of the unit. Needed to know if schedulers should run here.
     """
 
     framework: str
@@ -51,6 +55,16 @@ class WorkloadConfig:  # pylint: disable=too-many-instance-attributes
     log_files: List[pathlib.Path]
     metrics_target: str | None = None
     metrics_path: str | None = "/metrics"
+    unit_name: str
+
+    def should_run_scheduler(self) -> bool:
+        """Return if the unit should run scheduler processes.
+
+        Return:
+            True if the unit should run scheduler processes, False otherwise.
+        """
+        unit_id = self.unit_name.split("/")[1]
+        return unit_id == "0"
 
 
 class App:
@@ -191,6 +205,18 @@ class App:
 
         services[self._workload_config.service_name]["override"] = "replace"
         services[self._workload_config.service_name]["environment"] = self.gen_environment()
+
+        for service_name, service in services.items():
+            # Add environment variables to all worker processes.
+            if service_name.endswith(WORKER_SUFFIX):
+                service["environment"] = self.gen_environment()
+            # For scheduler processes, add environment variables if
+            # the scheduler should run in the unit, disable it otherwise.
+            if service_name.endswith(SCHEDULER_SUFFIX):
+                if self._workload_config.should_run_scheduler():
+                    service["environment"] = self.gen_environment()
+                else:
+                    service["startup"] = "disabled"
 
         return ops.pebble.LayerDict(services=services)
 

--- a/paas_app_charmer/charm.py
+++ b/paas_app_charmer/charm.py
@@ -128,7 +128,7 @@ class PaasCharm(abc.ABC, ops.CharmBase):  # pylint: disable=too-many-instance-at
         )
 
         self._observability = Observability(
-            self,
+            charm=self,
             log_files=self._workload_config.log_files,
             container_name=self._workload_config.container_name,
             cos_dir=self.get_cos_dir(),

--- a/paas_app_charmer/charm_state.py
+++ b/paas_app_charmer/charm_state.py
@@ -80,6 +80,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
     @classmethod
     def from_charm(  # pylint: disable=too-many-arguments
         cls,
+        *,
         charm: ops.CharmBase,
         framework: str,
         framework_config: BaseModel,
@@ -221,6 +222,7 @@ class IntegrationsState:
     @classmethod
     def build(  # pylint: disable=too-many-arguments
         cls,
+        *,
         redis_uri: str | None,
         database_requirers: dict[str, DatabaseRequires],
         s3_connection_info: dict[str, str] | None,

--- a/paas_app_charmer/database_migration.py
+++ b/paas_app_charmer/database_migration.py
@@ -75,6 +75,7 @@ class DatabaseMigration:
     # pylint: disable=too-many-arguments
     def run(
         self,
+        *,
         command: list[str],
         environment: dict[str, str],
         working_dir: pathlib.Path,

--- a/paas_app_charmer/fastapi/charm.py
+++ b/paas_app_charmer/fastapi/charm.py
@@ -72,6 +72,7 @@ class Charm(PaasCharm):
             log_files=[],
             metrics_target=f"*:{framework_config.metrics_port}",
             metrics_path=framework_config.metrics_path,
+            unit_name=self.unit.name,
         )
 
     def get_cos_dir(self) -> str:

--- a/paas_app_charmer/go/charm.py
+++ b/paas_app_charmer/go/charm.py
@@ -64,6 +64,7 @@ class Charm(PaasCharm):
             log_files=[],
             metrics_target=f"*:{framework_config.metrics_port}",
             metrics_path=framework_config.metrics_path,
+            unit_name=self.unit.name,
         )
 
     def get_cos_dir(self) -> str:

--- a/paas_app_charmer/observability.py
+++ b/paas_app_charmer/observability.py
@@ -17,6 +17,7 @@ class Observability(ops.Object):
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
+        *,
         charm: ops.CharmBase,
         container_name: str,
         cos_dir: str,

--- a/tests/integration/flask/test_workers.py
+++ b/tests/integration/flask/test_workers.py
@@ -7,6 +7,7 @@ import asyncio
 import logging
 import time
 
+import pytest
 import requests
 from juju.application import Application
 from juju.model import Model
@@ -16,28 +17,28 @@ from pytest_operator.plugin import OpsTest
 logger = logging.getLogger(__name__)
 
 
-async def test_workers_services_one_node(
-    ops_test: OpsTest, model: Model, flask_app: Application, get_unit_ips
+@pytest.mark.parametrize(
+    "num_units",
+    [1, 3],
+)
+@pytest.mark.usefixtures("integrate_redis_k8s_flask")
+async def test_workers_and_scheduler_services(
+    ops_test: OpsTest, model: Model, flask_app: Application, get_unit_ips, num_units: int
 ):
     """
-    arrange: TODO
-    act: TODO
-    assert: TODO
+    arrange: Flask and redis deployed and integrated.
+    act: Scale the app to the desired number of units.
+    assert: There should be only one scheduler and as many workers as units. That will
+            be checked because the scheduler is constantly sending tasks with its hostname
+            to the workers, and the workers will put its own hostname and the schedulers
+            hostname in Redis sets. Those sets are checked through the Flask app,
+            that queries Redis.
     """
-    redis_app_name = "redis-k8s"
-    redis_app = await model.deploy(redis_app_name, channel="edge")
-    await model.wait_for_idle(apps=[redis_app.name], status="active")
+    await flask_app.scale(num_units)
+    await model.wait_for_idle(apps=[flask_app.name], status="active")
 
-    await model.integrate(flask_app.name, redis_app.name)
-    await model.wait_for_idle(apps=[redis_app.name, flask_app.name], status="active")
-
-    # the flask unit is not important
+    # the flask unit is not important. Take the first one
     flask_unit_ip = (await get_unit_ips(flask_app.name))[0]
-
-    # clean the current celery stats
-    response = requests.get(f"http://{flask_unit_ip}:8000/redis/clear_celery_stats", timeout=5)
-    assert response.status_code == 200
-    assert "SUCCESS" == response.text
 
     def check_correct_celery_stats(num_schedulers, num_workers):
         """Check that the expected number of workers and schedulers is right."""
@@ -52,28 +53,16 @@ async def test_workers_services_one_node(
         )
         return len(data["workers"]) == num_workers and len(data["schedulers"]) == num_schedulers
 
-    time.sleep(3)  # enough time for all the schedulers to send messages
-    try:
-        await block_until(
-            lambda: check_correct_celery_stats(num_schedulers=1, num_workers=1),
-            timeout=20,
-            wait_period=1,
-        )
-    except asyncio.TimeoutError:
-        assert False, "Failed to get 1 worker and 1 scheduler"
-
-    await flask_app.scale(2)
-    await model.wait_for_idle(apps=[flask_app.name], status="active")
-
     # clean the current celery stats
     response = requests.get(f"http://{flask_unit_ip}:8000/redis/clear_celery_stats", timeout=5)
     assert response.status_code == 200
     assert "SUCCESS" == response.text
 
-    time.sleep(3)  # enough time for all the schedulers to send messages
+    # enough time for all the schedulers to send messages
+    time.sleep(10)
     try:
         await block_until(
-            lambda: check_correct_celery_stats(num_schedulers=1, num_workers=2),
+            lambda: check_correct_celery_stats(num_schedulers=1, num_workers=num_units),
             timeout=60,
             wait_period=1,
         )

--- a/tests/integration/flask/test_workers.py
+++ b/tests/integration/flask/test_workers.py
@@ -1,0 +1,81 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Integration tests for Flask workers and schedulers."""
+
+import asyncio
+import logging
+import time
+
+import requests
+from juju.application import Application
+from juju.model import Model
+from juju.utils import block_until
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+
+async def test_workers_services_one_node(
+    ops_test: OpsTest, model: Model, flask_app: Application, get_unit_ips
+):
+    """
+    arrange: TODO
+    act: TODO
+    assert: TODO
+    """
+    redis_app_name = "redis-k8s"
+    redis_app = await model.deploy(redis_app_name, channel="edge")
+    await model.wait_for_idle(apps=[redis_app.name], status="active")
+
+    await model.integrate(flask_app.name, redis_app.name)
+    await model.wait_for_idle(apps=[redis_app.name, flask_app.name], status="active")
+
+    # the flask unit is not important
+    flask_unit_ip = (await get_unit_ips(flask_app.name))[0]
+
+    # clean the current celery stats
+    response = requests.get(f"http://{flask_unit_ip}:8000/redis/clear_celery_stats", timeout=5)
+    assert response.status_code == 200
+    assert "SUCCESS" == response.text
+
+    def check_correct_celery_stats(num_schedulers, num_workers):
+        """Check that the expected number of workers and schedulers is right."""
+        response = requests.get(f"http://{flask_unit_ip}:8000/redis/celery_stats", timeout=5)
+        assert response.status_code == 200
+        data = response.json()
+        logger.info(
+            "check_correct_celery_stats. Expected schedulers: %d, expected workers %d. Result %s",
+            num_schedulers,
+            num_workers,
+            data,
+        )
+        return len(data["workers"]) == num_workers and len(data["schedulers"]) == num_schedulers
+
+    time.sleep(3)  # enough time for all the schedulers to send messages
+    try:
+        await block_until(
+            lambda: check_correct_celery_stats(num_schedulers=1, num_workers=1),
+            timeout=20,
+            wait_period=1,
+        )
+    except asyncio.TimeoutError:
+        assert False, "Failed to get 1 worker and 1 scheduler"
+
+    await flask_app.scale(2)
+    await model.wait_for_idle(apps=[flask_app.name], status="active")
+
+    # clean the current celery stats
+    response = requests.get(f"http://{flask_unit_ip}:8000/redis/clear_celery_stats", timeout=5)
+    assert response.status_code == 200
+    assert "SUCCESS" == response.text
+
+    time.sleep(3)  # enough time for all the schedulers to send messages
+    try:
+        await block_until(
+            lambda: check_correct_celery_stats(num_schedulers=1, num_workers=2),
+            timeout=60,
+            wait_period=1,
+        )
+    except asyncio.TimeoutError:
+        assert False, "Failed to get 2 workers and 1 scheduler"

--- a/tests/unit/django/test_charm.py
+++ b/tests/unit/django/test_charm.py
@@ -63,7 +63,7 @@ def test_django_config(harness: Harness, config: dict, env: dict) -> None:
         database_requirers={},
     )
     webserver_config = WebserverConfig.from_charm_config(harness.charm.config)
-    workload_config = create_workload_config(framework_name="django")
+    workload_config = create_workload_config(framework_name="django", unit_name="django/0")
     webserver = GunicornWebserver(
         webserver_config=webserver_config,
         workload_config=workload_config,

--- a/tests/unit/flask/constants.py
+++ b/tests/unit/flask/constants.py
@@ -25,6 +25,48 @@ DEFAULT_LAYER = {
         },
     }
 }
+
+LAYER_WITH_WORKER = {
+    "services": {
+        "flask": {
+            "override": "replace",
+            "startup": "enabled",
+            "command": f"/bin/python3 -m gunicorn -c /flask/gunicorn.conf.py app:app",
+            "after": ["statsd-exporter"],
+            "user": "_daemon_",
+        },
+        "statsd-exporter": {
+            "override": "merge",
+            "command": (
+                "/bin/statsd_exporter --statsd.mapping-config=/statsd-mapping.conf "
+                "--statsd.listen-udp=localhost:9125 "
+                "--statsd.listen-tcp=localhost:9125"
+            ),
+            "summary": "statsd exporter service",
+            "startup": "enabled",
+            "user": "_daemon_",
+        },
+        "not-worker-service": {
+            "override": "replace",
+            "startup": "enabled",
+            "command": "/bin/noworker",
+            "user": "_daemon_",
+        },
+        "real-worker": {
+            "override": "replace",
+            "startup": "enabled",
+            "command": "/bin/worker",
+            "user": "_daemon_",
+        },
+        "real-scheduler": {
+            "override": "replace",
+            "startup": "enabled",
+            "command": "/bin/scheduler",
+            "user": "_daemon_",
+        },
+    }
+}
+
 FLASK_CONTAINER_NAME = "flask-app"
 
 SAML_APP_RELATION_DATA_EXAMPLE = {

--- a/tests/unit/flask/constants.py
+++ b/tests/unit/flask/constants.py
@@ -58,10 +58,22 @@ LAYER_WITH_WORKER = {
             "command": "/bin/worker",
             "user": "_daemon_",
         },
+        "Another-Real-WorkeR": {
+            "override": "replace",
+            "startup": "enabled",
+            "command": "/bin/worker",
+            "user": "_daemon_",
+        },
         "real-scheduler": {
             "override": "replace",
             "startup": "enabled",
             "command": "/bin/scheduler",
+            "user": "_daemon_",
+        },
+        "ANOTHER-REAL-SCHEDULER": {
+            "override": "replace",
+            "startup": "enabled",
+            "command": "/bin/worker",
             "user": "_daemon_",
         },
     }

--- a/tests/unit/flask/test_charm.py
+++ b/tests/unit/flask/test_charm.py
@@ -51,7 +51,7 @@ def test_flask_pebble_layer(harness: Harness) -> None:
         database_requirers={},
     )
     webserver_config = WebserverConfig.from_charm_config(harness.charm.config)
-    workload_config = create_workload_config(framework_name="flask")
+    workload_config = create_workload_config(framework_name="flask", unit_name="flask/0")
     webserver = GunicornWebserver(
         webserver_config=webserver_config,
         workload_config=workload_config,

--- a/tests/unit/flask/test_database_migration.py
+++ b/tests/unit/flask/test_database_migration.py
@@ -35,7 +35,7 @@ def test_database_migration(harness: Harness):
         is_secret_storage_ready=True,
         secret_key="",
     )
-    workload_config = create_workload_config(framework_name="flask")
+    workload_config = create_workload_config(framework_name="flask", unit_name="flask/0")
     webserver_config = WebserverConfig()
     webserver = GunicornWebserver(
         webserver_config=webserver_config,
@@ -109,7 +109,7 @@ def test_database_migrate_command(harness: Harness, file: str, command: list[str
         secret_key="",
     )
     webserver_config = WebserverConfig()
-    workload_config = create_workload_config(framework_name="flask")
+    workload_config = create_workload_config(framework_name="flask", unit_name="flask/0")
     webserver = GunicornWebserver(
         webserver_config=webserver_config,
         workload_config=workload_config,

--- a/tests/unit/flask/test_database_migration.py
+++ b/tests/unit/flask/test_database_migration.py
@@ -150,8 +150,12 @@ def test_database_migration_status(harness: Harness):
     )
     assert database_migration.get_status() == DatabaseMigrationStatus.PENDING
     with pytest.raises(CharmConfigInvalidError):
-        database_migration.run(["migrate"], {}, pathlib.Path("/flask/app"))
+        database_migration.run(
+            command=["migrate"], environment={}, working_dir=pathlib.Path("/flask/app")
+        )
     assert database_migration.get_status() == DatabaseMigrationStatus.FAILED
     harness.handle_exec(container, [], result=0)
-    database_migration.run(["migrate"], {}, pathlib.Path("/flask/app"))
+    database_migration.run(
+        command=["migrate"], environment={}, working_dir=pathlib.Path("/flask/app")
+    )
     assert database_migration.get_status() == DatabaseMigrationStatus.COMPLETED

--- a/tests/unit/flask/test_flask_app.py
+++ b/tests/unit/flask/test_flask_app.py
@@ -41,7 +41,7 @@ def test_flask_env(flask_config: dict, app_config: dict, database_migration_mock
         framework_config=flask_config,
         app_config=app_config,
     )
-    workload_config = create_workload_config(framework_name="flask")
+    workload_config = create_workload_config(framework_name="flask", unit_name="flask/0")
     flask_app = WsgiApp(
         container=unittest.mock.MagicMock(),
         charm_state=charm_state,
@@ -104,7 +104,7 @@ def test_http_proxy(
         secret_key="foobar",
         is_secret_storage_ready=True,
     )
-    workload_config = create_workload_config(framework_name="flask")
+    workload_config = create_workload_config(framework_name="flask", unit_name="flask/0")
     flask_app = WsgiApp(
         container=unittest.mock.MagicMock(),
         charm_state=charm_state,
@@ -157,7 +157,7 @@ def test_integrations_env(
         is_secret_storage_ready=True,
         integrations=integrations,
     )
-    workload_config = create_workload_config(framework_name="flask")
+    workload_config = create_workload_config(framework_name="flask", unit_name="flask/0")
     flask_app = WsgiApp(
         container=unittest.mock.MagicMock(),
         charm_state=charm_state,

--- a/tests/unit/flask/test_webserver.py
+++ b/tests/unit/flask/test_webserver.py
@@ -73,7 +73,7 @@ def test_gunicorn_config(
         secret_key="",
         is_secret_storage_ready=True,
     )
-    workload_config = create_workload_config(framework_name="flask")
+    workload_config = create_workload_config(framework_name="flask", unit_name="flask/0")
     webserver_config = WebserverConfig(**charm_state_params)
     webserver = GunicornWebserver(
         webserver_config=webserver_config,
@@ -116,7 +116,7 @@ def test_webserver_reload(monkeypatch, harness: Harness, is_running, database_mi
         is_secret_storage_ready=True,
     )
     webserver_config = WebserverConfig()
-    workload_config = create_workload_config(framework_name="flask")
+    workload_config = create_workload_config(framework_name="flask", unit_name="flask/0")
     webserver = GunicornWebserver(
         webserver_config=webserver_config,
         workload_config=workload_config,
@@ -171,7 +171,7 @@ def test_gunicorn_config_with_pebble_log_forwarding(
         secret_key="",
         is_secret_storage_ready=True,
     )
-    workload_config = create_workload_config(framework_name="flask")
+    workload_config = create_workload_config(framework_name="flask", unit_name="flask/0")
     webserver_config = WebserverConfig()
     webserver = GunicornWebserver(
         webserver_config=webserver_config,

--- a/tests/unit/flask/test_workers.py
+++ b/tests/unit/flask/test_workers.py
@@ -4,11 +4,11 @@
 """Unit tests for worker services."""
 
 import copy
-import pytest
 import unittest.mock
 from secrets import token_hex
 
 import ops
+import pytest
 from ops.testing import Harness
 
 from .constants import FLASK_CONTAINER_NAME, LAYER_WITH_WORKER

--- a/tests/unit/flask/test_workers.py
+++ b/tests/unit/flask/test_workers.py
@@ -1,0 +1,66 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for worker services."""
+
+import unittest.mock
+from secrets import token_hex
+
+import ops
+from ops.testing import Harness
+
+from .constants import FLASK_CONTAINER_NAME, LAYER_WITH_WORKER
+
+
+def test_worker(harness: Harness):
+    """
+    arrange: Prepare a unit with workers
+    act: Run initial hooks.
+    assert: The workers should have all the environment variables. Also the schedulers, as
+            the unit is 0.
+    """
+    container = harness.model.unit.get_container(FLASK_CONTAINER_NAME)
+    container.add_layer("a_layer", LAYER_WITH_WORKER)
+
+    harness.begin_with_initial_hooks()
+
+    assert harness.model.unit.status == ops.ActiveStatus()
+    services = container.get_plan().services
+    assert "FLASK_SECRET_KEY" in services["flask"].environment
+    assert services["flask"].environment == services["real-worker"].environment
+    assert services["real-scheduler"].startup == "enabled"
+    assert services["flask"].environment == services["real-scheduler"].environment
+    assert "FLASK_SECRET_KEY" not in services["not-worker-service"].environment
+
+
+def test_worker_multiple_units(harness: Harness):
+    """
+    arrange: Prepare a unit with workers that is not the first one (number 1)
+    act: Run initial hooks.
+    assert: The workers should have all the environment variables. The schedulers should be
+            disabled and not have the environment variables
+    """
+
+    # This is tricky and could be problematic
+    harness.framework.model.unit.name = f"{harness._meta.name}/1"
+    harness.set_planned_units(3)
+
+    # Just think that we are not the leader unit. For this it is necessary to put data
+    # in the peer relation for the secret..
+    harness.set_leader(False)
+    harness.add_relation(
+        "secret-storage", harness.framework.model.app.name, app_data={"flask_secret_key": "XX"}
+    )
+
+    container = harness.model.unit.get_container(FLASK_CONTAINER_NAME)
+    container.add_layer("a_layer", LAYER_WITH_WORKER)
+
+    harness.begin_with_initial_hooks()
+
+    assert harness.model.unit.status == ops.ActiveStatus()
+    services = container.get_plan().services
+    assert "FLASK_SECRET_KEY" in services["flask"].environment
+    assert services["flask"].environment == services["real-worker"].environment
+    assert services["real-scheduler"].startup == "disabled"
+    assert "FLASK_SECRET_KEY" not in services["real-scheduler"].environment
+    assert "FLASK_SECRET_KEY" not in services["not-worker-service"].environment

--- a/tests/unit/go/test_app.py
+++ b/tests/unit/go/test_app.py
@@ -94,6 +94,7 @@ def test_go_environment_vars(
         log_files=[],
         metrics_target=f"*:{framework_config.metrics_port}",
         metrics_path=framework_config.metrics_path,
+        unit_name="go/0",
     )
 
     charm_state = CharmState(


### PR DESCRIPTION
Applicable spec: <link>
ISD181 - Background tasks in 12 factor apps

### Overview

<!-- A high level overview of the change -->

This PR implement background services in 12 factor apps, using the `paas-app-charmer` library.

Services defined in `rockcraft.yaml` with their name ending in `-worker` will be injected the same environment variables as the main service and will these background services will run in all units.

Services defined in `rockcraft.yaml` with their name ending in `-scheduler` will be injected the same environment variables as the main service, but will only run in the unit ending in name 0. This pod will always exists if there at least one unit (juju does not set .spec.ordinals.start, see [here](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#ordinal-index) for reference.

The integration test for the PR is complex, as it uses Celery beat and Celery workers. The Celery beat will send tasks to the workers, with an argument that is the Celery beat hostname. The Celery workers will put in a Redis set the hostname of the beat scheduler (received as an argument) and its own hostname in another set. Checking the sets we can see how many schedulers and worker services are working in all the units in the application. 

As a simpler alternative, it could be possible to  directly check which services are started in each unit and if they contain environment variables.

Documentation will be handled in different PRs/posts.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
