### PR TITLE
Add secret configurations

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -14,7 +14,7 @@ jobs:
       extra-arguments: -x --localstack-address 172.17.0.1
       pre-run-script: localstack-installation.sh
       charmcraft-channel: latest/edge
-      modules: '["test_charm.py", "test_cos.py", "test_database.py", "test_db_migration.py", "test_django.py", "test_django_integrations.py", "test_fastapi.py", "test_go.py", "test_integrations.py", "test_proxy.py"]'
+      modules: '["test_charm.py", "test_cos.py", "test_database.py", "test_db_migration.py", "test_django.py", "test_django_integrations.py", "test_fastapi.py", "test_go.py", "test_integrations.py", "test_proxy.py", "test_workers.py"]'
       rockcraft-repository: javierdelapuente/rockcraft
       rockcraft-ref: fastapi-extension
       juju-channel: ${{ matrix.juju-version }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -14,7 +14,7 @@ jobs:
       extra-arguments: -x --localstack-address 172.17.0.1
       pre-run-script: localstack-installation.sh
       charmcraft-channel: latest/edge
-      modules: '["test_charm.py", "test_cos.py", "test_database.py", "test_db_migration.py", "test_django.py", "test_django_integrations.py", "test_fastapi.py", "test_go.py", "test_integrations.py", "test_proxy.py", "test_workers.py"]'
+      modules: '["test_charm.py", "test_cos.py", "test_database.py", "test_db_migration.py", "test_django.py", "test_django_integrations.py", "test_fastapi.py", "test_go.py", "test_integrations.py", "test_proxy.py"]'
       rockcraft-repository: javierdelapuente/rockcraft
       rockcraft-ref: fastapi-extension
       juju-channel: ${{ matrix.juju-version }}

--- a/examples/django/charm/charmcraft.yaml
+++ b/examples/django/charm/charmcraft.yaml
@@ -53,7 +53,7 @@ config:
         This configuration is similar to `django-secret-key`, but instead accepts a Juju user secret ID. 
         The secret should contain a single key, "value", which maps to the actual Django secret key. 
         To create the secret, run the following command: 
-        `juju add-secret my-django-secret-key value=secret-string && juju grant-secret my-django-secret-key django-k8s`,
+        `juju add-secret my-django-secret-key value=<secret-string> && juju grant-secret my-django-secret-key django-k8s`,
         and use the outputted secret ID to configure this option.
       type: secret
     webserver-keepalive:

--- a/examples/django/charm/charmcraft.yaml
+++ b/examples/django/charm/charmcraft.yaml
@@ -49,6 +49,12 @@ config:
         will set the DJANGO_SECRET_KEY environment variable.
       type: string
     django-secret-key-id:
+      description: >-
+        This configuration is similar to `django-secret-key`, but instead accepts a Juju user secret ID. 
+        The secret should contain a single key, "value", which maps to the actual Django secret key. 
+        To create the secret, run the following command: 
+        `juju add-secret my-django-secret-key value=secret-string && juju grant-secret my-django-secret-key django-k8s`,
+        and use the outputted secret ID to configure this option.
       type: secret
     webserver-keepalive:
       description: Time in seconds for webserver to wait for requests on a Keep-Alive

--- a/examples/django/charm/charmcraft.yaml
+++ b/examples/django/charm/charmcraft.yaml
@@ -48,6 +48,8 @@ config:
         for any other security related needs by your Django application. This configuration
         will set the DJANGO_SECRET_KEY environment variable.
       type: string
+    django-secret-key-id:
+      type: secret
     webserver-keepalive:
       description: Time in seconds for webserver to wait for requests on a Keep-Alive
         connection.

--- a/examples/fastapi/charm/charmcraft.yaml
+++ b/examples/fastapi/charm/charmcraft.yaml
@@ -49,6 +49,12 @@ config:
          you need a random secret shared by all units
     app-secret-key-id:
       type: secret
+      description: >-
+        This configuration is similar to `app-secret-key`, but instead accepts a Juju user secret ID. 
+        The secret should contain a single key, "value", which maps to the actual secret key. 
+        To create the secret, run the following command: 
+        `juju add-secret my-secret-key value=secret-string && juju grant-secret my-secret-key flastapi-k8s`,
+        and use the outputted secret ID to configure this option.
     user-defined-config:
       type: string
       description: Example of a user defined configuration.

--- a/examples/fastapi/charm/charmcraft.yaml
+++ b/examples/fastapi/charm/charmcraft.yaml
@@ -47,6 +47,8 @@ config:
       type: string
       description: Long secret you can use for sessions, csrf or any other thing where
          you need a random secret shared by all units
+    app-secret-key-id:
+      type: secret
     user-defined-config:
       type: string
       description: Example of a user defined configuration.

--- a/examples/fastapi/charm/charmcraft.yaml
+++ b/examples/fastapi/charm/charmcraft.yaml
@@ -53,7 +53,7 @@ config:
         This configuration is similar to `app-secret-key`, but instead accepts a Juju user secret ID. 
         The secret should contain a single key, "value", which maps to the actual secret key. 
         To create the secret, run the following command: 
-        `juju add-secret my-secret-key value=secret-string && juju grant-secret my-secret-key fastapi-k8s`,
+        `juju add-secret my-secret-key value=<secret-string> && juju grant-secret my-secret-key fastapi-k8s`,
         and use the outputted secret ID to configure this option.
     user-defined-config:
       type: string

--- a/examples/fastapi/charm/charmcraft.yaml
+++ b/examples/fastapi/charm/charmcraft.yaml
@@ -53,7 +53,7 @@ config:
         This configuration is similar to `app-secret-key`, but instead accepts a Juju user secret ID. 
         The secret should contain a single key, "value", which maps to the actual secret key. 
         To create the secret, run the following command: 
-        `juju add-secret my-secret-key value=secret-string && juju grant-secret my-secret-key flastapi-k8s`,
+        `juju add-secret my-secret-key value=secret-string && juju grant-secret my-secret-key fastapi-k8s`,
         and use the outputted secret ID to configure this option.
     user-defined-config:
       type: string

--- a/examples/flask/charmcraft.yaml
+++ b/examples/flask/charmcraft.yaml
@@ -58,7 +58,7 @@ config:
     flask-secret-key-id:
       description: >-
         This configuration is similar to `flask-secret-key`, but instead accepts a Juju user secret ID. 
-        The secret should contain a single key, "value", which maps to the actual Django secret key. 
+        The secret should contain a single key, "value", which maps to the actual Flask secret key. 
         To create the secret, run the following command: 
         `juju add-secret my-flask-secret-key value=secret-string && juju grant-secret my-flask-secret-key flask-k8s`,
         and use the outputted secret ID to configure this option.
@@ -83,7 +83,7 @@ config:
       description: The number of webserver worker processes for handling requests.
       type: int
     secret-test:
-      description: A test configuration option for testing user provided juju secrets.
+      description: A test configuration option for testing user provided Juju secrets.
       type: secret
 containers:
   flask-app:

--- a/examples/flask/charmcraft.yaml
+++ b/examples/flask/charmcraft.yaml
@@ -55,6 +55,8 @@ config:
         will set the FLASK_SECRET_KEY environment variable. Run `app.config.from_prefixed_env()`
         in your Flask application in order to receive this configuration.
       type: string
+    flask-secret-key-id:
+      type: secret
     flask-session-cookie-secure:
       description: Set the secure attribute in the Flask application cookies. This
         configuration will set the FLASK_SESSION_COOKIE_SECURE environment variable.
@@ -74,6 +76,9 @@ config:
     webserver-workers:
       description: The number of webserver worker processes for handling requests.
       type: int
+    secret-test:
+      description: A test configuration option for testing user provided juju secrets.
+      type: secret
 containers:
   flask-app:
     resource: flask-app-image

--- a/examples/flask/charmcraft.yaml
+++ b/examples/flask/charmcraft.yaml
@@ -56,6 +56,12 @@ config:
         in your Flask application in order to receive this configuration.
       type: string
     flask-secret-key-id:
+      description: >-
+        This configuration is similar to `flask-secret-key`, but instead accepts a Juju user secret ID. 
+        The secret should contain a single key, "value", which maps to the actual Django secret key. 
+        To create the secret, run the following command: 
+        `juju add-secret my-flask-secret-key value=secret-string && juju grant-secret my-flask-secret-key flask-k8s`,
+        and use the outputted secret ID to configure this option.
       type: secret
     flask-session-cookie-secure:
       description: Set the secure attribute in the Flask application cookies. This

--- a/examples/flask/charmcraft.yaml
+++ b/examples/flask/charmcraft.yaml
@@ -60,7 +60,7 @@ config:
         This configuration is similar to `flask-secret-key`, but instead accepts a Juju user secret ID. 
         The secret should contain a single key, "value", which maps to the actual Flask secret key. 
         To create the secret, run the following command: 
-        `juju add-secret my-flask-secret-key value=secret-string && juju grant-secret my-flask-secret-key flask-k8s`,
+        `juju add-secret my-flask-secret-key value=<secret-string> && juju grant-secret my-flask-secret-key flask-k8s`,
         and use the outputted secret ID to configure this option.
       type: secret
     flask-session-cookie-secure:

--- a/examples/go/charm/charmcraft.yaml
+++ b/examples/go/charm/charmcraft.yaml
@@ -40,6 +40,12 @@ config:
          you need a random secret shared by all units
     app-secret-key-id:
       type: secret
+      description: >-
+        This configuration is similar to `app-secret-key`, but instead accepts a Juju user secret ID. 
+        The secret should contain a single key, "value", which maps to the actual secret key. 
+        To create the secret, run the following command: 
+        `juju add-secret my-secret-key value=secret-string && juju grant-secret my-secret-key go-k8s`,
+        and use the outputted secret ID to configure this option.
     user-defined-config:
       type: string
       description: Example of a user defined configuration.

--- a/examples/go/charm/charmcraft.yaml
+++ b/examples/go/charm/charmcraft.yaml
@@ -44,7 +44,7 @@ config:
         This configuration is similar to `app-secret-key`, but instead accepts a Juju user secret ID. 
         The secret should contain a single key, "value", which maps to the actual secret key. 
         To create the secret, run the following command: 
-        `juju add-secret my-secret-key value=secret-string && juju grant-secret my-secret-key go-k8s`,
+        `juju add-secret my-secret-key value=<secret-string> && juju grant-secret my-secret-key go-k8s`,
         and use the outputted secret ID to configure this option.
     user-defined-config:
       type: string

--- a/examples/go/charm/charmcraft.yaml
+++ b/examples/go/charm/charmcraft.yaml
@@ -38,6 +38,8 @@ config:
       type: string
       description: Long secret you can use for sessions, csrf or any other thing where
          you need a random secret shared by all units
+    app-secret-key-id:
+      type: secret
     user-defined-config:
       type: string
       description: Example of a user defined configuration.

--- a/paas_app_charmer/app.py
+++ b/paas_app_charmer/app.py
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 
 """Provide the base generic class to represent the application."""
-
+import collections
 import json
 import logging
 import pathlib
@@ -118,9 +118,16 @@ class App:
         Returns:
             A dictionary representing the application environment variables.
         """
-        config = self._charm_state.app_config
         prefix = self.configuration_prefix
-        env = {f"{prefix}{k.upper()}": encode_env(v) for k, v in config.items()}
+        env = {}
+        for app_config_key, app_config_value in self._charm_state.app_config.items():
+            if isinstance(app_config_value, collections.abc.Mapping):
+                for k, v in app_config_value.items():
+                    env[f"{prefix}{app_config_key.upper()}_{k.replace('-', '_').upper()}"] = (
+                        encode_env(v)
+                    )
+            else:
+                env[f"{prefix}{app_config_key.upper()}"] = encode_env(app_config_value)
 
         framework_config = self._charm_state.framework_config
         framework_config_prefix = self.framework_config_prefix

--- a/paas_app_charmer/charm.py
+++ b/paas_app_charmer/charm.py
@@ -143,8 +143,7 @@ class PaasCharm(abc.ABC, ops.CharmBase):  # pylint: disable=too-many-instance-at
             self._on_secret_storage_relation_changed,
         )
         self.framework.observe(self.on.update_status, self._on_update_status)
-        if ops.JujuVersion.from_environ().has_secrets:
-            self.framework.observe(self.on.secret_changed, self._on_secret_changed)
+        self.framework.observe(self.on.secret_changed, self._on_secret_changed)
         for database, database_requirer in self._database_requirers.items():
             self.framework.observe(
                 database_requirer.on.database_created,
@@ -188,21 +187,13 @@ class PaasCharm(abc.ABC, ops.CharmBase):  # pylint: disable=too-many-instance-at
         return self.unit.get_container(self._workload_config.container_name)
 
     @block_if_invalid_config
-    def _on_config_changed(self, _event: ops.EventBase) -> None:
-        """Configure the application pebble service layer.
-
-        Args:
-            _event: the config-changed event that triggers this callback function.
-        """
+    def _on_config_changed(self, _: ops.EventBase) -> None:
+        """Configure the application pebble service layer."""
         self.restart()
 
     @block_if_invalid_config
-    def _on_secret_changed(self, _event: ops.EventBase) -> None:
-        """Configure the application Pebble service layer.
-
-        Args:
-            _event: the secret-changed event that triggers this callback function.
-        """
+    def _on_secret_changed(self, _: ops.EventBase) -> None:
+        """Configure the application Pebble service layer."""
         self.restart()
 
     @block_if_invalid_config
@@ -223,12 +214,8 @@ class PaasCharm(abc.ABC, ops.CharmBase):  # pylint: disable=too-many-instance-at
         self.restart()
 
     @block_if_invalid_config
-    def _on_secret_storage_relation_changed(self, _event: ops.RelationEvent) -> None:
-        """Handle the secret-storage-relation-changed event.
-
-        Args:
-            _event: the action event that triggers this callback.
-        """
+    def _on_secret_storage_relation_changed(self, _: ops.RelationEvent) -> None:
+        """Handle the secret-storage-relation-changed event."""
         self.restart()
 
     def update_app_and_unit_status(self, status: ops.StatusBase) -> None:
@@ -371,67 +358,67 @@ class PaasCharm(abc.ABC, ops.CharmBase):  # pylint: disable=too-many-instance-at
             self.restart()
 
     @block_if_invalid_config
-    def _on_mysql_database_database_created(self, _event: DatabaseRequiresEvent) -> None:
+    def _on_mysql_database_database_created(self, _: DatabaseRequiresEvent) -> None:
         """Handle mysql's database-created event."""
         self.restart()
 
     @block_if_invalid_config
-    def _on_mysql_database_endpoints_changed(self, _event: DatabaseRequiresEvent) -> None:
+    def _on_mysql_database_endpoints_changed(self, _: DatabaseRequiresEvent) -> None:
         """Handle mysql's endpoints-changed event."""
         self.restart()
 
     @block_if_invalid_config
-    def _on_mysql_database_relation_broken(self, _event: ops.RelationBrokenEvent) -> None:
+    def _on_mysql_database_relation_broken(self, _: ops.RelationBrokenEvent) -> None:
         """Handle mysql's relation-broken event."""
         self.restart()
 
     @block_if_invalid_config
-    def _on_postgresql_database_database_created(self, _event: DatabaseRequiresEvent) -> None:
+    def _on_postgresql_database_database_created(self, _: DatabaseRequiresEvent) -> None:
         """Handle postgresql's database-created event."""
         self.restart()
 
     @block_if_invalid_config
-    def _on_postgresql_database_endpoints_changed(self, _event: DatabaseRequiresEvent) -> None:
+    def _on_postgresql_database_endpoints_changed(self, _: DatabaseRequiresEvent) -> None:
         """Handle mysql's endpoints-changed event."""
         self.restart()
 
     @block_if_invalid_config
-    def _on_postgresql_database_relation_broken(self, _event: ops.RelationBrokenEvent) -> None:
+    def _on_postgresql_database_relation_broken(self, _: ops.RelationBrokenEvent) -> None:
         """Handle postgresql's relation-broken event."""
         self.restart()
 
     @block_if_invalid_config
-    def _on_mongodb_database_database_created(self, _event: DatabaseRequiresEvent) -> None:
+    def _on_mongodb_database_database_created(self, _: DatabaseRequiresEvent) -> None:
         """Handle mongodb's database-created event."""
         self.restart()
 
     @block_if_invalid_config
-    def _on_mongodb_database_endpoints_changed(self, _event: DatabaseRequiresEvent) -> None:
+    def _on_mongodb_database_endpoints_changed(self, _: DatabaseRequiresEvent) -> None:
         """Handle mysql's endpoints-changed event."""
         self.restart()
 
     @block_if_invalid_config
-    def _on_mongodb_database_relation_broken(self, _event: ops.RelationBrokenEvent) -> None:
+    def _on_mongodb_database_relation_broken(self, _: ops.RelationBrokenEvent) -> None:
         """Handle postgresql's relation-broken event."""
         self.restart()
 
     @block_if_invalid_config
-    def _on_redis_relation_updated(self, _event: DatabaseRequiresEvent) -> None:
+    def _on_redis_relation_updated(self, _: DatabaseRequiresEvent) -> None:
         """Handle redis's database-created event."""
         self.restart()
 
     @block_if_invalid_config
-    def _on_s3_credential_changed(self, _event: ops.HookEvent) -> None:
+    def _on_s3_credential_changed(self, _: ops.HookEvent) -> None:
         """Handle s3 credentials-changed event."""
         self.restart()
 
     @block_if_invalid_config
-    def _on_s3_credential_gone(self, _event: ops.HookEvent) -> None:
+    def _on_s3_credential_gone(self, _: ops.HookEvent) -> None:
         """Handle s3 credentials-gone event."""
         self.restart()
 
     @block_if_invalid_config
-    def _on_saml_data_available(self, _event: ops.HookEvent) -> None:
+    def _on_saml_data_available(self, _: ops.HookEvent) -> None:
         """Handle saml data available event."""
         self.restart()
 
@@ -451,16 +438,16 @@ class PaasCharm(abc.ABC, ops.CharmBase):  # pylint: disable=too-many-instance-at
         self.restart()
 
     @block_if_invalid_config
-    def _on_rabbitmq_connected(self, _event: ops.HookEvent) -> None:
+    def _on_rabbitmq_connected(self, _: ops.HookEvent) -> None:
         """Handle rabbitmq connected event."""
         self.restart()
 
     @block_if_invalid_config
-    def _on_rabbitmq_ready(self, _event: ops.HookEvent) -> None:
+    def _on_rabbitmq_ready(self, _: ops.HookEvent) -> None:
         """Handle rabbitmq ready event."""
         self.restart()
 
     @block_if_invalid_config
-    def _on_rabbitmq_departed(self, _event: ops.HookEvent) -> None:
+    def _on_rabbitmq_departed(self, _: ops.HookEvent) -> None:
         """Handle rabbitmq departed event."""
         self.restart()

--- a/paas_app_charmer/charm.py
+++ b/paas_app_charmer/charm.py
@@ -198,7 +198,7 @@ class PaasCharm(abc.ABC, ops.CharmBase):  # pylint: disable=too-many-instance-at
 
     @block_if_invalid_config
     def _on_secret_changed(self, _event: ops.EventBase) -> None:
-        """Configure the application pebble service layer.
+        """Configure the application Pebble service layer.
 
         Args:
             _event: the secret-changed event that triggers this callback function.

--- a/paas_app_charmer/charm_state.py
+++ b/paas_app_charmer/charm_state.py
@@ -9,14 +9,13 @@ import typing
 from dataclasses import dataclass, field
 from typing import Optional
 
-import ops
 from charms.data_platform_libs.v0.data_interfaces import DatabaseRequires
 from pydantic import BaseModel, Extra, Field, ValidationError, ValidationInfo, field_validator
 
 from paas_app_charmer.databases import get_uri
 from paas_app_charmer.exceptions import CharmConfigInvalidError
 from paas_app_charmer.secret_storage import KeySecretStorage
-from paas_app_charmer.utils import build_validation_error_message, config_get_3
+from paas_app_charmer.utils import build_validation_error_message
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +79,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
     @classmethod
     def from_charm(  # pylint: disable=too-many-arguments
         cls,
-        charm: ops.CharmBase,
+        config: dict[str, bool | int | float | str | dict[str, str]],
         framework: str,
         framework_config: BaseModel,
         secret_storage: KeySecretStorage,
@@ -94,7 +93,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
         """Initialize a new instance of the CharmState class from the associated charm.
 
         Args:
-            charm: The charm instance associated with this state.
+            config: The charm configuration.
             framework: The framework name.
             framework_config: The framework specific configurations.
             secret_storage: The secret storage manager associated with the charm.
@@ -109,8 +108,8 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
             The CharmState instance created by the provided charm.
         """
         app_config = {
-            k.replace("-", "_"): config_get_3(charm, k)
-            for k in charm.config.keys()
+            k.replace("-", "_"): v
+            for k, v in config.items()
             if not any(k.startswith(prefix) for prefix in (f"{framework}-", "webserver-", "app-"))
         }
         app_config = {

--- a/paas_app_charmer/django/charm.py
+++ b/paas_app_charmer/django/charm.py
@@ -53,7 +53,7 @@ class DjangoConfig(BaseModel, extra=Extra.ignore):
             data: model input.
 
         Returns:
-            modified input with *-secret-key replace by the secret content of *-secret-key-id.
+            modified input with *-secret-key replaced by the secret content of *-secret-key-id.
 
         Raises:
             ValueError: if the *-secret-key-id is invalid.

--- a/paas_app_charmer/fastapi/charm.py
+++ b/paas_app_charmer/fastapi/charm.py
@@ -46,7 +46,7 @@ class FastAPIConfig(BaseModel, extra=Extra.ignore):
             data: model input.
 
         Returns:
-            modified input with *-secret-key replace by the secret content of *-secret-key-id.
+            modified input with *-secret-key replaced by the secret content of *-secret-key-id.
 
         Raises:
             ValueError: if the *-secret-key-id is invalid.

--- a/paas_app_charmer/fastapi/charm.py
+++ b/paas_app_charmer/fastapi/charm.py
@@ -7,13 +7,14 @@ import pathlib
 import typing
 
 import ops
-from pydantic import BaseModel, Extra, Field, model_validator
+from pydantic import ConfigDict, Field
 
 from paas_app_charmer.app import App, WorkloadConfig
 from paas_app_charmer.charm import PaasCharm
+from paas_app_charmer.framework import FrameworkConfig
 
 
-class FastAPIConfig(BaseModel, extra=Extra.ignore):
+class FastAPIConfig(FrameworkConfig):
     """Represent FastAPI builtin configuration values.
 
     Attrs:
@@ -25,6 +26,7 @@ class FastAPIConfig(BaseModel, extra=Extra.ignore):
         metrics_path: path where the metrics are collected
         app_secret_key: a secret key that will be used for securely signing the session cookie
             and can be used for any other security related needs by your Flask application.
+        model_config: Pydantic model configuration.
     """
 
     uvicorn_port: int = Field(alias="webserver-port", default=8080, gt=0)
@@ -37,26 +39,7 @@ class FastAPIConfig(BaseModel, extra=Extra.ignore):
     metrics_path: str | None = Field(alias="metrics-path", default=None, min_length=1)
     app_secret_key: str | None = Field(alias="app-secret-key", default=None, min_length=1)
 
-    @model_validator(mode="before")
-    @classmethod
-    def secret_key_id(cls, data: dict[str, str | int | bool | dict[str, str] | None]) -> dict:
-        """Read the new *-secret-key-id style configuration.
-
-        Args:
-            data: model input.
-
-        Returns:
-            modified input with *-secret-key replaced by the secret content of *-secret-key-id.
-
-        Raises:
-            ValueError: if the *-secret-key-id is invalid.
-        """
-        if "app-secret-key-id" in data and data["app-secret-key-id"]:
-            secret_value = typing.cast(dict[str, str], data["app-secret-key-id"])
-            if "value" not in secret_value:
-                raise ValueError("app-secret-key-id missing 'value' key in the secret content")
-            data["app-secret-key"] = secret_value["value"]
-        return data
+    model_config = ConfigDict(extra="ignore")
 
 
 class Charm(PaasCharm):

--- a/paas_app_charmer/flask/charm.py
+++ b/paas_app_charmer/flask/charm.py
@@ -67,7 +67,7 @@ class FlaskConfig(BaseModel, extra=Extra.ignore):
             data: model input.
 
         Returns:
-            modified input with *-secret-key replace by the secret content of *-secret-key-id.
+            modified input with *-secret-key replaced by the secret content of *-secret-key-id.
 
         Raises:
             ValueError: if the *-secret-key-id is invalid.

--- a/paas_app_charmer/framework.py
+++ b/paas_app_charmer/framework.py
@@ -23,6 +23,7 @@ class FrameworkConfig(pydantic.BaseModel):
 
         Raises:
             ValueError: if the *-secret-key-id is invalid.
+            NotImplementedError: ill-formed subclasses.
         """
         secret_key_field = "secret_key"
         if secret_key_field not in cls.model_fields:

--- a/paas_app_charmer/framework.py
+++ b/paas_app_charmer/framework.py
@@ -1,0 +1,47 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Framework related base classes."""
+import typing
+
+import pydantic
+
+
+class FrameworkConfig(pydantic.BaseModel):
+    """Base class for framework config models."""
+
+    @pydantic.model_validator(mode="before")
+    @classmethod
+    def secret_key_id(cls, data: dict[str, str | int | bool | dict[str, str] | None]) -> dict:
+        """Read the *-secret-key-id style configuration.
+
+        Args:
+            data: model input.
+
+        Returns:
+            modified input with *-secret-key replaced by the secret content of *-secret-key-id.
+
+        Raises:
+            ValueError: if the *-secret-key-id is invalid.
+        """
+        secret_key_field = "secret_key"
+        if secret_key_field not in cls.model_fields:
+            secret_key_field = "app_secret_key"
+        secret_key_config_name = cls.model_fields[secret_key_field].alias
+        assert secret_key_config_name
+        secret_key_id_config_name = f"{secret_key_config_name}-id"
+        if data.get(secret_key_id_config_name):
+            if data.get(secret_key_config_name):
+                raise ValueError(
+                    f"{secret_key_id_config_name} and {secret_key_config_name} "
+                    "are defined in the same time"
+                )
+            secret_value = typing.cast(dict[str, str], data[secret_key_id_config_name])
+            if "value" not in secret_value:
+                raise ValueError(
+                    f"{secret_key_id_config_name} missing 'value' key in the secret content"
+                )
+            if len(secret_value) > 1:
+                raise ValueError(f"{secret_key_id_config_name} secret contains multiple values")
+            data[secret_key_config_name] = secret_value["value"]
+        return data

--- a/paas_app_charmer/framework.py
+++ b/paas_app_charmer/framework.py
@@ -28,7 +28,8 @@ class FrameworkConfig(pydantic.BaseModel):
         if secret_key_field not in cls.model_fields:
             secret_key_field = "app_secret_key"
         secret_key_config_name = cls.model_fields[secret_key_field].alias
-        assert secret_key_config_name
+        if not secret_key_config_name:
+            raise NotImplementedError("framework configuration secret_key field has no alias")
         secret_key_id_config_name = f"{secret_key_config_name}-id"
         if data.get(secret_key_id_config_name):
             if data.get(secret_key_config_name):

--- a/paas_app_charmer/go/charm.py
+++ b/paas_app_charmer/go/charm.py
@@ -40,7 +40,7 @@ class GoConfig(BaseModel, extra=Extra.ignore):
             data: model input.
 
         Returns:
-            modified input with *-secret-key replace by the secret content of *-secret-key-id.
+            modified input with *-secret-key replaced by the secret content of *-secret-key-id.
 
         Raises:
             ValueError: if the *-secret-key-id is invalid.

--- a/paas_app_charmer/go/charm.py
+++ b/paas_app_charmer/go/charm.py
@@ -7,7 +7,7 @@ import pathlib
 import typing
 
 import ops
-from pydantic import BaseModel, Extra, Field
+from pydantic import BaseModel, Extra, Field, model_validator
 
 from paas_app_charmer.app import App, WorkloadConfig
 from paas_app_charmer.charm import PaasCharm
@@ -28,6 +28,29 @@ class GoConfig(BaseModel, extra=Extra.ignore):
     metrics_port: int | None = Field(alias="metrics-port", default=None, gt=0)
     metrics_path: str | None = Field(alias="metrics-path", default=None, min_length=1)
     secret_key: str | None = Field(alias="app-secret-key", default=None, min_length=1)
+
+    @model_validator(mode="before")
+    @classmethod
+    def secret_key_id(
+        cls, data: dict[str, str | int | bool | float | dict[str, str] | None]
+    ) -> dict:
+        """Read the new *-secret-key-id style configuration.
+
+        Args:
+            data: model input.
+
+        Returns:
+            modified input with *-secret-key replace by the secret content of *-secret-key-id.
+
+        Raises:
+            ValueError: if the *-secret-key-id is invalid.
+        """
+        if "app-secret-key-id" in data and data["app-secret-key-id"]:
+            secret_value = typing.cast(dict[str, str], data["app-secret-key-id"])
+            if "value" not in secret_value:
+                raise ValueError("app-secret-key-id missing 'value' key in the secret content")
+            data["app-secret-key"] = secret_value["value"]
+        return data
 
 
 class Charm(PaasCharm):

--- a/paas_app_charmer/utils.py
+++ b/paas_app_charmer/utils.py
@@ -79,13 +79,13 @@ def _config_metadata(charm_dir: pathlib.Path) -> dict:
     raise ValueError("charm configuration metadata doesn't exist")
 
 
-def config_get_3(
+def config_get_with_secret(
     charm: ops.CharmBase, key: str
-) -> str | int | bool | float | dict[str, str] | None:
+) -> str | int | bool | float | ops.Secret | None:
     """Get charm configuration values.
 
     This function differs from ``ops.CharmBase.config.get`` in that for secret-typed configuration
-    options, it returns the content of the secret instead of the secret ID in the configuration
+    options, it returns the secret object instead of the secret ID in the configuration
     value. In other instances, this function is equivalent to ops.CharmBase.config.get.
 
     Args:
@@ -102,5 +102,4 @@ def config_get_3(
     secret_id = charm.config.get(key)
     if secret_id is None:
         return None
-    secret = charm.model.get_secret(id=typing.cast(str, secret_id))
-    return secret.get_content(refresh=True)
+    return charm.model.get_secret(id=typing.cast(str, secret_id))

--- a/paas_app_charmer/utils.py
+++ b/paas_app_charmer/utils.py
@@ -2,10 +2,14 @@
 # See LICENSE file for licensing details.
 
 """Generic utility functions."""
-
+import functools
 import itertools
+import os
+import pathlib
+import typing
 
 import ops
+import yaml
 from pydantic import ValidationError
 
 
@@ -51,3 +55,52 @@ def enable_pebble_log_forwarding() -> bool:
         return True
     except ImportError:
         return False
+
+
+@functools.lru_cache
+def _config_metadata(charm_dir: pathlib.Path) -> dict:
+    """Get charm configuration metadata for the given charm directory.
+
+    Args:
+        charm_dir: Path to the charm directory.
+
+    Returns:
+        The charm configuration metadata.
+
+    Raises:
+            ValueError: if the charm_dir input is invalid.
+    """
+    config_file = charm_dir / "config.yaml"
+    if config_file.exists():
+        return yaml.safe_load(config_file.read_text())
+    config_file = charm_dir / "charmcraft.yaml"
+    if config_file.exists():
+        return yaml.safe_load(config_file.read_text())["config"]
+    raise ValueError("charm configuration metadata doesn't exist")
+
+
+def config_get_3(
+    charm: ops.CharmBase, key: str
+) -> str | int | bool | float | dict[str, str] | None:
+    """Get charm configuration values.
+
+    This function differs from ``ops.CharmBase.config.get`` in that for secret-typed configuration
+    options, it returns the content of the secret instead of the secret ID in the configuration
+    value. In other instances, this function is equivalent to ops.CharmBase.config.get.
+
+    Args:
+        charm: The charm instance.
+        key: The configuration option key.
+
+    Returns:
+        The configuration value.
+    """
+    metadata = _config_metadata(pathlib.Path(os.getcwd()))
+    config_type = metadata["options"][key]["type"]
+    if config_type != "secret":
+        return charm.config.get(key)
+    secret_id = charm.config.get(key)
+    if secret_id is None:
+        return None
+    secret = charm.model.get_secret(id=typing.cast(str, secret_id))
+    return secret.get_content(refresh=True)

--- a/tests/integration/flask/conftest.py
+++ b/tests/integration/flask/conftest.py
@@ -187,6 +187,34 @@ async def update_config(model: Model, request: FixtureRequest, flask_app: Applic
     await model.wait_for_idle(apps=[flask_app.name])
 
 
+@pytest_asyncio.fixture
+async def update_secret_config(model: Model, request: FixtureRequest, flask_app: Application):
+    """Update a secret flask application configuration.
+
+    This fixture must be parameterized with changing charm configurations.
+    """
+    orig_config = {k: v.get("value") for k, v in (await flask_app.get_config()).items()}
+    request_config = {}
+    for secret_config_option, secret_value in request.param.items():
+        secret_id = await model.add_secret(
+            secret_config_option, [f"{k}={v}" for k, v in secret_value.items()]
+        )
+        await model.grant_secret(secret_config_option, flask_app.name)
+        request_config[secret_config_option] = secret_id
+    await flask_app.set_config(request_config)
+    await model.wait_for_idle(apps=[flask_app.name])
+
+    yield request_config
+
+    # await flask_app.set_config(
+    #     {k: v for k, v in orig_config.items() if k in request_config and v is not None}
+    # )
+    # await flask_app.reset_config([k for k in request_config if orig_config[k] is None])
+    # for secret_name in request_config:
+    #     await model.remove_secret(secret_name)
+    # await model.wait_for_idle(apps=[flask_app.name])
+
+
 @pytest.fixture(scope="module", name="localstack_address")
 def localstack_address_fixture(pytestconfig: Config):
     """Provides localstack IP address to be used in the integration test."""

--- a/tests/integration/flask/conftest.py
+++ b/tests/integration/flask/conftest.py
@@ -206,13 +206,13 @@ async def update_secret_config(model: Model, request: FixtureRequest, flask_app:
 
     yield request_config
 
-    # await flask_app.set_config(
-    #     {k: v for k, v in orig_config.items() if k in request_config and v is not None}
-    # )
-    # await flask_app.reset_config([k for k in request_config if orig_config[k] is None])
-    # for secret_name in request_config:
-    #     await model.remove_secret(secret_name)
-    # await model.wait_for_idle(apps=[flask_app.name])
+    await flask_app.set_config(
+        {k: v for k, v in orig_config.items() if k in request_config and v is not None}
+    )
+    await flask_app.reset_config([k for k in request_config if orig_config[k] is None])
+    for secret_name in request_config:
+        await model.remove_secret(secret_name)
+    await model.wait_for_idle(apps=[flask_app.name])
 
 
 @pytest.fixture(scope="module", name="localstack_address")

--- a/tests/unit/django/test_charm.py
+++ b/tests/unit/django/test_charm.py
@@ -56,7 +56,7 @@ def test_django_config(harness: Harness, config: dict, env: dict) -> None:
     secret_storage.get_secret_key.return_value = "test"
     harness.update_config(config)
     charm_state = CharmState.from_charm(
-        charm=harness.charm,
+        config=harness.charm.config,
         framework="django",
         framework_config=harness.charm.get_framework_config(),
         secret_storage=secret_storage,

--- a/tests/unit/flask/test_charm.py
+++ b/tests/unit/flask/test_charm.py
@@ -45,7 +45,7 @@ def test_flask_pebble_layer(harness: Harness) -> None:
     secret_storage.get_secret_key.return_value = test_key
     charm_state = CharmState.from_charm(
         framework_config=Charm.get_framework_config(harness.charm),
-        charm=harness.charm,
+        config=harness.charm.config,
         framework="flask",
         secret_storage=secret_storage,
         database_requirers={},

--- a/tests/unit/flask/test_charm_state.py
+++ b/tests/unit/flask/test_charm_state.py
@@ -314,7 +314,6 @@ def test_flask_secret_key_id():
     assert: framework_config in the charm state should contain the value of the secret.
     """
     config = copy.copy(DEFAULT_CHARM_CONFIG)
-    config["flask-secret-key"] = "foo"
     config["flask-secret-key-id"] = "secret://id"
     charm = unittest.mock.MagicMock(
         config=config,
@@ -344,6 +343,36 @@ def test_flask_secret_key_id_no_value():
     assert: It should raise CharmConfigInvalidError.
     """
     config = copy.copy(DEFAULT_CHARM_CONFIG)
+    config["flask-secret-key-id"] = "secret://id"
+    charm = unittest.mock.MagicMock(
+        config=config,
+        framework_config_class=Charm.framework_config_class,
+        model=unittest.mock.MagicMock(
+            get_secret=unittest.mock.MagicMock(
+                return_value=unittest.mock.MagicMock(
+                    get_content=unittest.mock.MagicMock(return_value={"foobar": "foobar"}),
+                )
+            ),
+        ),
+    )
+    with pytest.raises(CharmConfigInvalidError) as exc:
+        CharmState.from_charm(
+            framework="flask",
+            framework_config=Charm.get_framework_config(charm),
+            secret_storage=SECRET_STORAGE_MOCK,
+            charm=charm,
+            database_requirers={},
+        )
+
+
+def test_flask_secret_key_id_duplication():
+    """
+    arrange: Provide both the flask-secret-key-id and flask-secret-key configuration.
+    act: Try to build CharmState.
+    assert: It should raise CharmConfigInvalidError.
+    """
+    config = copy.copy(DEFAULT_CHARM_CONFIG)
+    config["flask-secret-key"] = "test"
     config["flask-secret-key-id"] = "secret://id"
     charm = unittest.mock.MagicMock(
         config=config,


### PR DESCRIPTION
### Overview

Users can now provide Juju user secrets as configuration values by using the `secret`-typed configuration options. For user-defined configurations, the secret value is flattened before being passed to the application via environment variables. For instance, if a user defines a new configuration option `my-secret` and sets its value to a Juju user secret ID containing `{"foo-bar": "foobar", "bar": "bar"}`, the environment variables passed to the application will be `FLASK_MY_SECRET_FOO_BAR=foobar` and `FLASK_MY_SECRET_BAR=bar`.

Additionally, we have introduced a new built-in configuration option for Flask, Django, Golang, and FastAPI, called `*-secret-key-id`, which replaces the older `*-secret-key` configuration option. The new `*-secret-key-id` option accepts a Juju secret ID containing `{"value": "secret-key-..."}`. While the older `*-secret-key` option is still supported, it will have lower priority compared to `*-secret-key-id`.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
