### PR TITLE
Improve test resilience

### DIFF
--- a/tests/integration/flask/conftest.py
+++ b/tests/integration/flask/conftest.py
@@ -271,11 +271,13 @@ async def rabbitmq_server_integration_fixture(
     rabbitmq_offer_url = f"{lxd_controller_name}:{lxd_username}/{lxd_model_name}.{offer_name}"
 
     integration = await model.integrate(rabbitmq_offer_url, flask_app.name)
+    await lxd_model.wait_for_idle(status="active")
     await model.wait_for_idle(apps=[flask_app.name], status="active")
 
     yield integration
 
     res = await flask_app.destroy_relation("rabbitmq", f"{rabbitmq_server_app.name}:amqp")
+    await lxd_model.wait_for_idle(status="active")
     await model.wait_for_idle(apps=[flask_app.name], status="active")
 
 
@@ -287,9 +289,9 @@ async def rabbitmq_k8s_integration_fixture(
 ):
     """Integrates flask with rabbitmq-k8s."""
     integration = await model.integrate(rabbitmq_k8s_app.name, flask_app.name)
-    await model.wait_for_idle(apps=[flask_app.name], status="active")
+    await model.wait_for_idle(apps=[flask_app.name, rabbitmq_k8s_app.name], status="active")
 
     yield integration
 
     await flask_app.destroy_relation("rabbitmq", f"{rabbitmq_k8s_app.name}:amqp")
-    await model.wait_for_idle(apps=[flask_app.name], status="active")
+    await model.wait_for_idle(apps=[flask_app.name, rabbitmq_k8s_app.name], status="active")


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

The integrations tests have failed in my local machine. Improve the waiting mechanism so they are more robust.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
