### PR TITLE
Create celery_app even if there is no broker_url for integ test

### DIFF
--- a/examples/flask/test_rock/rockcraft.yaml
+++ b/examples/flask/test_rock/rockcraft.yaml
@@ -15,15 +15,13 @@ extensions:
 services:
   celery-worker:
     override: replace
-    # redis is not mandatory in the charm. We do not want the charm to fail immediately, so the sleep
-    command: bash -c "sleep 5; celery -A app:celery_app worker -c 2 --loglevel DEBUG"
+    command: celery -A app:celery_app worker -c 2 --loglevel DEBUG
     startup: enabled
     user: _daemon_
     working-dir: /flask/app
   celery-beat-scheduler:
     override: replace
-    # redis is not mandatory in the charm. We do not want the charm to fail immediately, so the sleep
-    command: bash -c "sleep 5; celery -A app:celery_app beat --loglevel DEBUG -s /tmp/celerybeat-schedule"
+    command: celery -A app:celery_app beat --loglevel DEBUG -s /tmp/celerybeat-schedule
     startup: enabled
     user: _daemon_
     working-dir: /flask/app


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

For the examples for workers and schedulers, create always the Celery app, even if there is no broker url. That way, the rockcrack.yaml file does not need to be run with bash (as Celery will always start), and sets a better example of use for the background tasks. 

Suggested by @amandahla https://github.com/canonical/paas-app-charmer/pull/44#discussion_r1773261829. Thanks!

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
