### PR TITLE
Migrate should rerun when integrations are added (for example for optional integrations)

### DIFF
--- a/paas_app_charmer/charm.py
+++ b/paas_app_charmer/charm.py
@@ -299,8 +299,15 @@ class PaasCharm(abc.ABC, ops.CharmBase):  # pylint: disable=too-many-instance-at
                 missing_integrations.append("rabbitmq")
         return missing_integrations
 
-    def restart(self) -> None:
-        """Restart or start the service if not started with the latest configuration."""
+    def restart(self, rerun_migrations: bool = False) -> None:
+        """Restart or start the service if not started with the latest configuration.
+
+        Args:
+            rerun_migrations: whether it is necessary to run the migrations again.
+        """
+        if rerun_migrations:
+            self._database_migration.set_status_to_pending()
+
         if not self.is_ready():
             return
         try:
@@ -375,12 +382,12 @@ class PaasCharm(abc.ABC, ops.CharmBase):  # pylint: disable=too-many-instance-at
     @block_if_invalid_config
     def _on_mysql_database_database_created(self, _: DatabaseRequiresEvent) -> None:
         """Handle mysql's database-created event."""
-        self.restart()
+        self.restart(rerun_migrations=True)
 
     @block_if_invalid_config
     def _on_mysql_database_endpoints_changed(self, _: DatabaseRequiresEvent) -> None:
         """Handle mysql's endpoints-changed event."""
-        self.restart()
+        self.restart(rerun_migrations=True)
 
     @block_if_invalid_config
     def _on_mysql_database_relation_broken(self, _: ops.RelationBrokenEvent) -> None:
@@ -390,12 +397,12 @@ class PaasCharm(abc.ABC, ops.CharmBase):  # pylint: disable=too-many-instance-at
     @block_if_invalid_config
     def _on_postgresql_database_database_created(self, _: DatabaseRequiresEvent) -> None:
         """Handle postgresql's database-created event."""
-        self.restart()
+        self.restart(rerun_migrations=True)
 
     @block_if_invalid_config
     def _on_postgresql_database_endpoints_changed(self, _: DatabaseRequiresEvent) -> None:
         """Handle mysql's endpoints-changed event."""
-        self.restart()
+        self.restart(rerun_migrations=True)
 
     @block_if_invalid_config
     def _on_postgresql_database_relation_broken(self, _: ops.RelationBrokenEvent) -> None:
@@ -405,12 +412,12 @@ class PaasCharm(abc.ABC, ops.CharmBase):  # pylint: disable=too-many-instance-at
     @block_if_invalid_config
     def _on_mongodb_database_database_created(self, _: DatabaseRequiresEvent) -> None:
         """Handle mongodb's database-created event."""
-        self.restart()
+        self.restart(rerun_migrations=True)
 
     @block_if_invalid_config
     def _on_mongodb_database_endpoints_changed(self, _: DatabaseRequiresEvent) -> None:
         """Handle mysql's endpoints-changed event."""
-        self.restart()
+        self.restart(rerun_migrations=True)
 
     @block_if_invalid_config
     def _on_mongodb_database_relation_broken(self, _: ops.RelationBrokenEvent) -> None:
@@ -425,7 +432,7 @@ class PaasCharm(abc.ABC, ops.CharmBase):  # pylint: disable=too-many-instance-at
     @block_if_invalid_config
     def _on_s3_credential_changed(self, _: ops.HookEvent) -> None:
         """Handle s3 credentials-changed event."""
-        self.restart()
+        self.restart(rerun_migrations=True)
 
     @block_if_invalid_config
     def _on_s3_credential_gone(self, _: ops.HookEvent) -> None:
@@ -435,7 +442,7 @@ class PaasCharm(abc.ABC, ops.CharmBase):  # pylint: disable=too-many-instance-at
     @block_if_invalid_config
     def _on_saml_data_available(self, _: ops.HookEvent) -> None:
         """Handle saml data available event."""
-        self.restart()
+        self.restart(rerun_migrations=True)
 
     @block_if_invalid_config
     def _on_ingress_revoked(self, _: ops.HookEvent) -> None:
@@ -460,7 +467,7 @@ class PaasCharm(abc.ABC, ops.CharmBase):  # pylint: disable=too-many-instance-at
     @block_if_invalid_config
     def _on_rabbitmq_ready(self, _: ops.HookEvent) -> None:
         """Handle rabbitmq ready event."""
-        self.restart()
+        self.restart(rerun_migrations=True)
 
     @block_if_invalid_config
     def _on_rabbitmq_departed(self, _: ops.HookEvent) -> None:

--- a/paas_app_charmer/charm.py
+++ b/paas_app_charmer/charm.py
@@ -427,7 +427,7 @@ class PaasCharm(abc.ABC, ops.CharmBase):  # pylint: disable=too-many-instance-at
     @block_if_invalid_config
     def _on_redis_relation_updated(self, _: DatabaseRequiresEvent) -> None:
         """Handle redis's database-created event."""
-        self.restart()
+        self.restart(rerun_migrations=True)
 
     @block_if_invalid_config
     def _on_s3_credential_changed(self, _: ops.HookEvent) -> None:

--- a/tests/unit/flask/test_database_migration.py
+++ b/tests/unit/flask/test_database_migration.py
@@ -174,7 +174,7 @@ def test_migrations_run_second_time_optional_integration_integrated(harness: Har
     (root / "flask/app/migrate.sh").touch()
     exec_handler = unittest.mock.MagicMock()
     exec_handler.return_value = None
-    harness.handle_exec(container, ['bash', '-eo', 'pipefail', 'migrate.sh'], handler=exec_handler)
+    harness.handle_exec(container, ["bash", "-eo", "pipefail", "migrate.sh"], handler=exec_handler)
     harness.begin_with_initial_hooks()
     # First migration was called.
     exec_handler.assert_called_once()
@@ -182,7 +182,7 @@ def test_migrations_run_second_time_optional_integration_integrated(harness: Har
 
     exec_handler = unittest.mock.MagicMock()
     exec_handler.return_value = None
-    harness.handle_exec(container, ['bash', '-eo', 'pipefail', 'migrate.sh'], handler=exec_handler)
+    harness.handle_exec(container, ["bash", "-eo", "pipefail", "migrate.sh"], handler=exec_handler)
     postgresql_relation_data = {
         "database": "test-database",
         "endpoints": "test-postgresql:5432,test-postgresql-2:5432",

--- a/tests/unit/flask/test_database_migration.py
+++ b/tests/unit/flask/test_database_migration.py
@@ -172,17 +172,21 @@ def test_migrations_run_second_time_optional_integration_integrated(harness: Har
     container.add_layer("a_layer", DEFAULT_LAYER)
     root = harness.get_filesystem_root(container)
     (root / "flask/app/migrate.sh").touch()
-    exec_handler = unittest.mock.MagicMock()
-    exec_handler.return_value = None
-    harness.handle_exec(container, ["bash", "-eo", "pipefail", "migrate.sh"], handler=exec_handler)
+    first_exec_handler = unittest.mock.MagicMock()
+    first_exec_handler.return_value = None
+    harness.handle_exec(
+        container, ["bash", "-eo", "pipefail", "migrate.sh"], handler=first_exec_handler
+    )
     harness.begin_with_initial_hooks()
     # First migration was called.
-    exec_handler.assert_called_once()
+    first_exec_handler.assert_called_once()
     assert harness.model.unit.status == ops.ActiveStatus()
 
-    exec_handler = unittest.mock.MagicMock()
-    exec_handler.return_value = None
-    harness.handle_exec(container, ["bash", "-eo", "pipefail", "migrate.sh"], handler=exec_handler)
+    second_exec_handler = unittest.mock.MagicMock()
+    second_exec_handler.return_value = None
+    harness.handle_exec(
+        container, ["bash", "-eo", "pipefail", "migrate.sh"], handler=second_exec_handler
+    )
     postgresql_relation_data = {
         "database": "test-database",
         "endpoints": "test-postgresql:5432,test-postgresql-2:5432",
@@ -192,5 +196,5 @@ def test_migrations_run_second_time_optional_integration_integrated(harness: Har
     harness.add_relation("postgresql", "postgresql-k8s", app_data=postgresql_relation_data)
 
     # The second migration was called.
-    exec_handler.assert_called_once()
+    second_exec_handler.assert_called_once()
     assert harness.model.unit.status == ops.ActiveStatus()

--- a/tests/unit/flask/test_database_migration.py
+++ b/tests/unit/flask/test_database_migration.py
@@ -3,6 +3,7 @@
 
 """Unit tests for Flask charm database integration."""
 import pathlib
+import unittest.mock
 
 import ops
 import pytest
@@ -159,3 +160,37 @@ def test_database_migration_status(harness: Harness):
         command=["migrate"], environment={}, working_dir=pathlib.Path("/flask/app")
     )
     assert database_migration.get_status() == DatabaseMigrationStatus.COMPLETED
+
+
+def test_migrations_run_second_time_optional_integration_integrated(harness: Harness):
+    """
+    arrange: set up a active charm that has run the migration successfully.
+    act: integrate with a new optional integration.
+    assert: the migration command should be called again.
+    """
+    container = harness.model.unit.get_container(FLASK_CONTAINER_NAME)
+    container.add_layer("a_layer", DEFAULT_LAYER)
+    root = harness.get_filesystem_root(container)
+    (root / "flask/app/migrate.sh").touch()
+    exec_handler = unittest.mock.MagicMock()
+    exec_handler.return_value = None
+    harness.handle_exec(container, ['bash', '-eo', 'pipefail', 'migrate.sh'], handler=exec_handler)
+    harness.begin_with_initial_hooks()
+    # First migration was called.
+    exec_handler.assert_called_once()
+    assert harness.model.unit.status == ops.ActiveStatus()
+
+    exec_handler = unittest.mock.MagicMock()
+    exec_handler.return_value = None
+    harness.handle_exec(container, ['bash', '-eo', 'pipefail', 'migrate.sh'], handler=exec_handler)
+    postgresql_relation_data = {
+        "database": "test-database",
+        "endpoints": "test-postgresql:5432,test-postgresql-2:5432",
+        "password": "test-password",
+        "username": "test-username",
+    }
+    harness.add_relation("postgresql", "postgresql-k8s", app_data=postgresql_relation_data)
+
+    # The second migration was called.
+    exec_handler.assert_called_once()
+    assert harness.model.unit.status == ops.ActiveStatus()


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

Currently, migrations run the first the charm is active, when the charm is refreshed and when the charm is active again after missing integrations are readded.

However, in the case of optional integrations, we want the migration process to run again when an optional integration is added, so the migration script can do whatever is necessary with its integration (for example an optional database to optionally persist data).

As the script for migrations should be idempotent, no issues should arise for calling it extra times.


### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
